### PR TITLE
Fix warning about attribute order

### DIFF
--- a/src/views/Viewer.vue
+++ b/src/views/Viewer.vue
@@ -31,8 +31,8 @@
 		@previous="previous"
 		@next="next">
 		<component
-			v-show="false"
 			:is="previousFile.modal"
+			v-show="false"
 			ref="previous-content"
 			:key="previousFile.path"
 			:mime="previousFile.mime"
@@ -46,8 +46,8 @@
 			:active="true"
 			@loaded="doneLoading" />
 		<component
-			v-show="false"
 			:is="nextFile.modal"
+			v-show="false"
 			ref="next-content"
 			:key="nextFile.path"
 			:mime="nextFile.mime"


### PR DESCRIPTION
During `make build-js` I got 2 warnings:

```
WARNING in ./src/views/Viewer.vue
Module Warning (from ./node_modules/eslint-loader/index.js):

/home/jan/nextcloud/apps/viewer/src/views/Viewer.vue
  35:4  warning  Attribute ":is" should go before "v-show"  vue/attributes-order
  50:4  warning  Attribute ":is" should go before "v-show"  vue/attributes-order
```

This fixes it. :) Please review @nextcloud/javascript 