### PR TITLE
Implement file actions menu

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,6 +7,7 @@ module.exports = {
 		jest: true
 	},
 	globals: {
+		$: true,
 		t: true,
 		n: true,
 		OC: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8877,11 +8877,6 @@
         }
       }
     },
-    "sax": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
-    },
     "schema-utils": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
@@ -11291,20 +11286,6 @@
       "resolved": "https://registry.npmjs.org/x-is-string/-/x-is-string-0.1.0.tgz",
       "integrity": "sha1-R0tQhlrzpJqcRlfwWs0UVFj3fYI=",
       "dev": true
-    },
-    "xml2js": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
-      "requires": {
-        "sax": ">=0.6.0",
-        "xmlbuilder": "~9.0.1"
-      }
-    },
-    "xmlbuilder": {
-      "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xtend": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
     "mime-types": "^2.1.22",
     "nextcloud-server": "^0.15.9",
     "nextcloud-vue": "^0.8.0",
-    "vue": "^2.6.7",
-    "xml2js": "^0.4.19"
+    "vue": "^2.6.7"
   },
   "browserslist": [
     "last 2 versions",

--- a/src/main.js
+++ b/src/main.js
@@ -25,6 +25,8 @@ import ViewerService from 'Services/Viewer'
 
 import { generateFilePath } from 'nextcloud-server/dist/router'
 
+Vue.prototype.$ = $
+
 Vue.prototype.t = t
 Vue.prototype.n = n
 

--- a/src/services/FileList.js
+++ b/src/services/FileList.js
@@ -21,7 +21,6 @@
  */
 
 import axios from 'axios'
-import { parseString } from 'xml2js'
 
 /**
  *
@@ -36,17 +35,42 @@ export default async function(user, path, mimes) {
 		headers: {
 			requesttoken: OC.requestToken,
 			'content-Type': 'text/xml'
-		}
+		},
+		data: `<?xml version="1.0"?>
+		<d:propfind  xmlns:d="DAV:"
+			xmlns:oc="http://owncloud.org/ns"
+			xmlns:nc="http://nextcloud.org/ns"
+			xmlns:ocs="http://open-collaboration-services.org/ns">
+		  <d:prop>
+			<d:getlastmodified />
+			<d:getetag />
+			<d:getcontenttype />
+			<d:resourcetype />
+			<oc:fileid />
+			<oc:permissions />
+			<oc:size />
+			<d:getcontentlength />
+			<nc:has-preview />
+			<nc:mount-type />
+			<nc:is-encrypted />
+			<ocs:share-permissions />
+			<oc:tags />
+			<oc:favorite />
+			<oc:comments-unread />
+			<oc:owner-id />
+			<oc:owner-display-name />
+			<oc:share-types />
+		  </d:prop>
+		</d:propfind>`
 	})
 
-	let files = []
-	await parseString(response.data, (error, data) => {
-		files = data['d:multistatus']['d:response']
-		if (error) {
-			console.error(error)
-		}
-	})
+	let files = OCA.Files.App.fileList.filesClient._client.parseMultiStatus(response.data)
 
-	return files.filter(file => file['d:propstat'][0]['d:prop'][0]['d:getcontenttype'] && mimes.indexOf(file['d:propstat'][0]['d:prop'][0]['d:getcontenttype'][0]) !== -1)
-
+	return files
+		.map(file => {
+			const fileInfo = OCA.Files.App.fileList.filesClient._parseFileInfo(file)
+			fileInfo.href = file.href
+			return fileInfo
+		})
+		.filter(file => file.mimetype && mimes.indexOf(file.mimetype) !== -1)
 }


### PR DESCRIPTION
Fix #7 

![capture d ecran_2019-03-01_11-44-33](https://user-images.githubusercontent.com/14975046/53633312-68b33480-3c17-11e9-9a09-19b757bec623.png)

___
## Issues, please give your insight
- Actions are not really reactive, clicking favourite does not change the menu item
- What would be the behaviour of clicking rename? Closing the slideshow?
- Lots of the actions require that the file is in the list, but the slideshow doe snot care about this and does not pursue loading the main files list. I'm not sure how to handle this case. Shall we scroll down while pressing next on the slideshow?
- How to properly detect the file deletion? If I click delete from the menu, it gets deleted in the backgroud, but how can I make the main app to know? I want to avoid creating dedicated edge-cases on the viewer (like if action === 'delete') because it would be a nightmare to manage. Thoughts?
- The popovermenu get hidden by the sidebar when opened. I can't get my head around this, since the modal is fixed, any children zindexes is ignored, therefore the sidebar can be under or above the whole modal, but cannot be between two element of the modal content! :woman_shrugging: 