### PR TITLE
Display original jpeg image instead of preview

### DIFF
--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -94,6 +94,8 @@ export default {
 				return this.getBase64FromImage()
 			case 'image/gif':
 				return this.davPath
+			case 'image/jpeg':
+				return this.davPath
 			default:
 				return this.previewpath
 			}


### PR DESCRIPTION
When displaying a jpeg image, viewer uses the preview. This results in poor display quality because typically the screen has a much higher resolution than the preview.
When viewing my photos I want to see the original. To browse the previews, the grid views in Files and Photos exist. Hence I suggest this change.