### PR TITLE
(Likely) fix flaky sidebar tests

### DIFF
--- a/cypress/integration/sidebar.spec.js
+++ b/cypress/integration/sidebar.spec.js
@@ -79,9 +79,9 @@ describe('Open the sidebar from the viewer and open viewer with sidebar already 
 
 	it('Open the sidebar', function() {
 		// open the menu
-		cy.get('body > .viewer .modal-header button.action-item__menutoggle').click()
-		// open the sidebar
-		cy.get('.action-button__icon.icon-menu-sidebar').click()
+		cy.get('body > .viewer .modal-header button.action-item__menutoggle').wait(300).click()
+		// open the sidebar (wait for the menu to be expanded)
+		cy.get('.action-button__icon.icon-menu-sidebar').wait(300).click()
 		cy.get('aside.app-sidebar').should('be.visible')
 		// we hide the sidebar button if opened
 		cy.get('.action-button__icon.icon-menu-sidebar').should('not.exist')


### PR DESCRIPTION
I think this might fix the flaky test for the sidebar.

The issue was likey caused because the click to open the menu occured while the header was not visible. The act of clicking
however revealed the header without opening the menu. As a concequence, the next step does not have a menu item to
click on.


successful runs via CI (triggered by force pushes to this branch):

1. https://dashboard.cypress.io/projects/xysa6x/runs/2555/specs
1. https://dashboard.cypress.io/projects/xysa6x/runs/2556/specs
1. https://dashboard.cypress.io/projects/xysa6x/runs/2557/specs
1. https://dashboard.cypress.io/projects/xysa6x/runs/2558/specs
1. https://dashboard.cypress.io/projects/xysa6x/runs/2559/specs