### PR TITLE
Add support for tiff and heif

### DIFF
--- a/src/models/images.js
+++ b/src/models/images.js
@@ -28,6 +28,8 @@ export default {
 	mimes: [
 		'image/png',
 		'image/heic',
+		'image/heif',
+		'image/tiff',
 		'image/jpeg',
 		'image/gif',
 		'image/x-xbitmap',


### PR DESCRIPTION
This still needs a preview provider that supports these image formats enabled to have the viewer open the image (data-has-preview=true). This is provided by the off by default imaginary image previewer or possibly other image providers or OC\Preview\HEIC and OC\Preview\TIFF

Signed-off-by: Carl Schwan <carl@carlschwan.eu>