### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/cypress/utils/index.js
+++ b/cypress/utils/index.js
@@ -30,4 +30,4 @@ export const getSearchParams = url => {
 		}, {})
 }
 
-export const randHash = () => Math.random().toString(36).replace(/[^a-z]+/g, '').substr(0, 10)
+export const randHash = () => Math.random().toString(36).replace(/[^a-z]+/g, '').slice(0, 10)


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.