### PR TITLE
Temporary Workaround for double clicking item bug

### DIFF
--- a/src/views/Viewer.vue
+++ b/src/views/Viewer.vue
@@ -634,6 +634,9 @@ export default {
 			if (OCA?.Files?.Sidebar) {
 				OCA.Files.Sidebar.setFullScreenMode(false)
 			}
+			
+			//a temporary workaround to deal with a bug that occurs when double clicking on an item in NextCloud.
+			this.cleanup();
 		},
 
 		cleanup() {


### PR DESCRIPTION
This is a temporary workaround for the bug that occurs when you double click an item that opens in the viewer.  It works for the Viewer for Images, Videos, and PDFs for sure.  I didn't test audio, but it probably works for it as well.

The main cause of the issue is that when a file is double clicked, the file is opened twice.  However, something weird occurs when this happens.  openFile() is only called once, while close() and cleanup() are immediately called.  What I'm guessing happens is that the original file loads, and is closed somehow, followed by the second file opening.  I'm not sure which of those files calls openFile() and which doesn't.  One result of this though is that when the second file is closed, close() is called, but cleanup() is not.  This patch ensures that it is called, which resolves the issue.

There are still some cases where the double clicking can cause the black background of the viewer to not appear (to get this to happen, you have to double click, but put some spaces between the clicks that are a part of the double click, it's difficult to get the timing right, so try it a few times).  But this at least solves the one issue.

Signed-off-by: Michael Pope <michael.pope.email@gmail.com>