### PR TITLE
fix: cypress login command with current server

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -37,7 +37,7 @@ Cypress.Commands.add('login', (user, password, route = '/apps/files') => {
 	cy.visit(route)
 	cy.get('input[name=user]').type(user)
 	cy.get('input[name=password]').type(password)
-	cy.get('form[name=login] input[type=submit]').click()
+	cy.get('form[name=login] [type=submit]').click()
 	cy.url().should('include', route)
 })
 


### PR DESCRIPTION
The submit element is now a button.
Use a selector that works with both.

Signed-off-by: Max <max@nextcloud.com>