### PR TITLE
Fix regression: Use Photos preview API for that webdav collection

### DIFF
--- a/src/mixins/PreviewUrl.js
+++ b/src/mixins/PreviewUrl.js
@@ -75,6 +75,10 @@ export default {
 				if (isPublic()) {
 					return generateUrl(`/apps/files_sharing/publicpreview/${getToken()}?file=${encodeFilePath(filename)}&${searchParams}`)
 				}
+				if (filename.startsWith('/photos/')) {
+					// May be a shared album; use Photos preview API
+					return generateUrl(`/apps/photos/api/v1/preview/${fileid}?${searchParams}`)
+				}
 				return generateUrl(`/core/preview?${searchParams}`)
 			}
 			return davPath


### PR DESCRIPTION
Fixes a regression where the viewer cannot show any photos from collaborative albums, since these previews are not accessible over the core API.

I unfortunately introduced this while fixing another regression in #1409 😩 
Any better ideas to do this? Using the source image directly isn't right because it might be _huge_ (plus no support for HEIC/TIFF), so this seems like the better option.