### PR TITLE
Migrate to @fontsource/roboto

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.0",
       "license": "agpl",
       "dependencies": {
+        "@fontsource/roboto": "^4.5.8",
         "@nextcloud/auth": "^2.0.0",
         "@nextcloud/axios": "^2.1.0",
         "@nextcloud/dialogs": "^3.2.0",
@@ -23,7 +24,6 @@
         "camelcase": "^7.0.0",
         "debounce": "^1.2.1",
         "filerobot-image-editor": "^4.3.7",
-        "fontsource-roboto": "^4.0.0",
         "nextcloud-server": "^0.15.10",
         "path-parse": "^1.0.7",
         "vue": "^2.7.13",
@@ -2028,6 +2028,11 @@
       "dependencies": {
         "@floating-ui/core": "^0.3.0"
       }
+    },
+    "node_modules/@fontsource/roboto": {
+      "version": "4.5.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-4.5.8.tgz",
+      "integrity": "sha512-CnD7zLItIzt86q4Sj3kZUiLcBk1dSk81qcqgMGaZe7SQ1P8hFNxhMl5AZthK1zrDM5m74VVhaOpuMGIL4gagaA=="
     },
     "node_modules/@hapi/hoek": {
       "version": "9.2.1",
@@ -8681,12 +8686,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/fontsource-roboto": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/fontsource-roboto/-/fontsource-roboto-4.0.0.tgz",
-      "integrity": "sha512-zD6L8nvdWRcwSgp4ojxFchG+MPj8kXXQKDEAH9bfhbxy+lkpvpC1WgAK0lCa4dwobv+hvAe0uyHaawcgH7WH/g==",
-      "deprecated": "Package relocated. Please install and migrate to @fontsource/roboto."
     },
     "node_modules/foreach": {
       "version": "2.0.5",
@@ -19863,6 +19862,11 @@
         "@floating-ui/core": "^0.3.0"
       }
     },
+    "@fontsource/roboto": {
+      "version": "4.5.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/roboto/-/roboto-4.5.8.tgz",
+      "integrity": "sha512-CnD7zLItIzt86q4Sj3kZUiLcBk1dSk81qcqgMGaZe7SQ1P8hFNxhMl5AZthK1zrDM5m74VVhaOpuMGIL4gagaA=="
+    },
     "@hapi/hoek": {
       "version": "9.2.1",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.2.1.tgz",
@@ -25186,11 +25190,6 @@
       "version": "1.14.9",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
       "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w=="
-    },
-    "fontsource-roboto": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/fontsource-roboto/-/fontsource-roboto-4.0.0.tgz",
-      "integrity": "sha512-zD6L8nvdWRcwSgp4ojxFchG+MPj8kXXQKDEAH9bfhbxy+lkpvpC1WgAK0lCa4dwobv+hvAe0uyHaawcgH7WH/g=="
     },
     "foreach": {
       "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "cypress:update-snapshots": "TESTING=true cypress run --env type=base --spec cypress/e2e/visual-regression.cy.js --config screenshotsFolder=cypress/snapshots/base"
   },
   "dependencies": {
+    "@fontsource/roboto": "^4.5.8",
     "@nextcloud/auth": "^2.0.0",
     "@nextcloud/axios": "^2.1.0",
     "@nextcloud/dialogs": "^3.2.0",
@@ -52,7 +53,6 @@
     "camelcase": "^7.0.0",
     "debounce": "^1.2.1",
     "filerobot-image-editor": "^4.3.7",
-    "fontsource-roboto": "^4.0.0",
     "nextcloud-server": "^0.15.10",
     "path-parse": "^1.0.7",
     "vue": "^2.7.13",

--- a/src/main.js
+++ b/src/main.js
@@ -35,7 +35,7 @@ Vue.mixin({
 // Inject proper font for cypress visual regression testing
 if (isTesting) {
 	// Import font so CI has the same
-	import(/* webpackChunkName: 'roboto-font' */'fontsource-roboto')
+	import(/* webpackChunkName: 'roboto-font' */'@fontsource/roboto')
 }
 
 Vue.prototype.OC = OC


### PR DESCRIPTION
```
npm WARN deprecated fontsource-roboto@4.0.0: Package relocated. Please install and migrate to @fontsource/roboto.
```
