### PR TITLE
Add AVIF

### DIFF
--- a/cypress/e2e/images/image.avif.cy.ts
+++ b/cypress/e2e/images/image.avif.cy.ts
@@ -1,0 +1,5 @@
+import imageTest from '../mixins/image'
+
+describe('Open image.avif in viewer', function() {
+	imageTest('image.avif', 'image/avif')
+})

--- a/src/models/images.js
+++ b/src/models/images.js
@@ -50,6 +50,7 @@ const browserSupportedMimes = [
 	'image/png',
 	'image/svg+xml',
 	'image/webp',
+	'image/avif',
 	'image/x-icon',
 ]
 

--- a/src/models/images.js
+++ b/src/models/images.js
@@ -33,6 +33,7 @@ const enabledPreviewProviders = loadState(appName, 'enabled_preview_providers', 
 const previewSupportedMimes = [
 	'image/heic',
 	'image/heif',
+	'image/avif',
 	'image/tiff',
 	'image/x-xbitmap',
 ]
@@ -50,7 +51,6 @@ const browserSupportedMimes = [
 	'image/png',
 	'image/svg+xml',
 	'image/webp',
-	'image/avif',
 	'image/x-icon',
 ]
 


### PR DESCRIPTION
I'm currently making a change to Nextcloud that allows for the creation of JPEG previews from AVIF images.
With this change, if the proposal is accepted, this app would also be up-to-date.
But there's still one question that needs to be answered: How good is the browser support for AVIF? Can it be added to the well-supported formats without Edge's support, or not?
The [browser support](https://caniuse.com/avif) for AVIF has greatly improved. Only Edge, Opera Mini, QQ Browser, KaiOS Browser, and of course IE don't support it anymore.

Closes #407