### PR TITLE
feat: enable viewer for image/emf

### DIFF
--- a/src/models/images.js
+++ b/src/models/images.js
@@ -35,6 +35,7 @@ const previewSupportedMimes = [
 	'image/heif',
 	'image/tiff',
 	'image/x-xbitmap',
+	'image/emf',
 ]
 
 /**


### PR DESCRIPTION
For https://github.com/nextcloud/files_emfviewer/issues/1

Add support for image/emf files through a generated preview.

The actual implementation, to generate a preview image, will be provided via app or server. 