### PR TITLE
fix(video): video fullscreen on ios devices

### DIFF
--- a/src/components/Videos.vue
+++ b/src/components/Videos.vue
@@ -99,6 +99,9 @@ export default {
 				blankVideo,
 				controls: ['play-large', 'play', 'progress', 'current-time', 'mute', 'volume', 'captions', 'settings', 'fullscreen'],
 				loadSprite: false,
+				fullscreen: {
+					iosNative: true,
+				}
 			}
 		},
 	},


### PR DESCRIPTION
This has been tested on an iPhone, an iPad and in the browser. It now works on iPhone and there are no regressions on the other tested devices.

## Before

Landscape | Portrait
--- | ---
![before-landscape](https://github.com/nextcloud/viewer/assets/1479486/296740eb-7fc1-4667-9ca7-9123a7932b84)| ![before-portrait](https://github.com/nextcloud/viewer/assets/1479486/d7bf44fc-2830-42d7-b49e-47633f30264d)

## After

Landscape | Portrait
--- | ---
![IMG_2675](https://github.com/nextcloud/viewer/assets/1479486/dbd031d3-2d75-44a4-92b6-0db5db325fb3) | ![IMG_2674](https://github.com/nextcloud/viewer/assets/1479486/c800fc43-9df1-465d-a059-a5d2ca458e9c)