### PR TITLE
feat(viewer): allow async handler components

### DIFF
--- a/src/views/Viewer.vue
+++ b/src/views/Viewer.vue
@@ -811,7 +811,7 @@ export default {
 			}
 
 			// checking valid handler component data
-			if ((!handler.component || typeof handler.component !== 'object')) {
+			if ((!handler.component || (typeof handler.component !== 'object' && typeof handler.component !== 'function'))) {
 				logger.error('The following handler doesn\'t have a valid component', { handler })
 				return
 			}


### PR DESCRIPTION
Allows use of async handlers

```js
OCA.Viewer.registerHandler({
	id: 'text',
	component: () => import('./components/ViewerComponent.vue'),
})
```

For https://github.com/nextcloud/text/pull/4698