### PR TITLE
fix: correct keys in Viewer template

### DIFF
--- a/src/views/Viewer.vue
+++ b/src/views/Viewer.vue
@@ -28,7 +28,7 @@
 		:data-handler="handlerId">
 		<component :is="currentFile.modal"
 			v-if="!currentFile.failed"
-			:key="currentFile | uniqueKey"
+			:key="getKeyForFile(currentFile)"
 			ref="content"
 			:active="true"
 			:can-swipe="false"
@@ -113,9 +113,10 @@
 
 		<div class="viewer__content" :class="contentClass" @click.self.exact="close">
 			<!-- COMPARE FILE -->
-			<div v-if="comparisonFile && !comparisonFile.failed && showComparison" class="viewer__file-wrapper">
+			<div v-if="comparisonFile && !comparisonFile.failed && showComparison"
+				:key="getKeyForFile(comparisonFile)"
+				class="viewer__file-wrapper">
 				<component :is="comparisonFile.modal"
-					:key="comparisonFile | uniqueKey"
 					ref="comparison-content"
 					v-bind="comparisonFile"
 					:active="true"
@@ -131,7 +132,7 @@
 
 			<!-- PREVIOUS -->
 			<div v-if="previousFile"
-				:key="previousFile | uniqueKey"
+				:key="getKeyForFile(previousFile)"
 				class="viewer__file-wrapper viewer__file-wrapper--hidden"
 				aria-hidden="true"
 				inert>
@@ -147,7 +148,7 @@
 			</div>
 
 			<!-- CURRENT -->
-			<div :key="currentFile | uniqueKey" class="viewer__file-wrapper">
+			<div :key="getKeyForFile(currentFile)" class="viewer__file-wrapper">
 				<component :is="currentFile.modal"
 					v-if="!currentFile.failed"
 					ref="content"
@@ -168,7 +169,7 @@
 
 			<!-- NEXT -->
 			<div v-if="nextFile"
-				:key="nextFile | uniqueKey"
+				:key="getKeyForFile(nextFile)"
 				class="viewer__file-wrapper viewer__file-wrapper--hidden"
 				aria-hidden="true"
 				inert>
@@ -241,12 +242,6 @@ export default {
 		NcActionLink,
 		NcModal,
 		Pencil,
-	},
-
-	filters: {
-		uniqueKey(file) {
-			return '' + file.fileid + file.source
-		},
 	},
 
 	mixins: [isFullscreen, isMobile],
@@ -1216,6 +1211,9 @@ export default {
 			}
 		},
 
+		getKeyForFile(file) {
+			return file.fileid || file.source
+		},
 	},
 }
 </script>


### PR DESCRIPTION
## Resolves

> [Vue warn]: Duplicate keys detected: 'undefinedundefined'. This may cause an update error.

![image](https://github.com/nextcloud/viewer/assets/25978914/7882eb1e-f9eb-4b53-97c0-c7cf05129abd)
