### PR TITLE
fix(requesttoken): Make sure to use the correct requesttoken in WebdavClient

### DIFF
--- a/js/viewer-main.mjs
+++ b/js/viewer-main.mjs
@@ -465,7 +465,7 @@ var b4=Object.defineProperty;var y4=(e,r,a)=>r in e?b4(e,r,{enumerable:!0,config
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
- */const dT={"X-Requested-With":"XMLHttpRequest",requesttoken:x0()||""},XD=()=>HD(k1(),Hs()?{username:R1(),password:"",headers:dT}:{headers:dT});/*! third party licenses: js/vendor.LICENSE.txt *//**
+ */const dT=()=>({"X-Requested-With":"XMLHttpRequest",requesttoken:x0()||""}),XD=()=>HD(k1(),Hs()?{username:R1(),password:"",headers:dT()}:{headers:dT()});/*! third party licenses: js/vendor.LICENSE.txt *//**
  * @copyright Copyright (c) 2019 John Molakvoæ <skjnldsv@protonmail.com>
  *
  * @author John Molakvoæ <skjnldsv@protonmail.com>

--- a/src/services/WebdavClient.ts
+++ b/src/services/WebdavClient.ts
@@ -24,17 +24,20 @@ import { createClient } from 'webdav'
 import { getRootPath, getToken, isPublic } from '../utils/davUtils'
 import { getRequestToken } from '@nextcloud/auth'
 
-const headers = {
-	// Add this so the server knows it is an request from the browser
-	'X-Requested-With': 'XMLHttpRequest',
-	// Add the request token to the request
-	requesttoken: getRequestToken() || '',
+// Use a method for the headers, to always get the current request token
+const getHeaders = () => {
+	return {
+		// Add this so the server knows it is an request from the browser
+		'X-Requested-With': 'XMLHttpRequest',
+		// Add the request token to the request
+		requesttoken: getRequestToken() || '',
+	}
 }
 
 export const getClient = () => {
 	const client = createClient(getRootPath(), isPublic()
-		? { username: getToken(), password: '', headers }
-		: { headers },
+		? { username: getToken(), password: '', headers: getHeaders() }
+		: { headers: getHeaders() },
 	)
 
 	return client


### PR DESCRIPTION
Fixes https://github.com/nextcloud/spreed/issues/12529

Introduced in https://github.com/nextcloud/viewer/pull/2178 / https://github.com/nextcloud/viewer/pull/2179

Before the PR the `getRequestToken` was called when `createClient` was called, so it always contained the current value. After the PR `getRequestToken` is only called once when the `headers` object is created, so it will never change, which leads to being unable to open some pictures (see talk issue above).