### PR TITLE
fix: Use relative paths to dav root

### DIFF
--- a/css/viewer-main.css
+++ b/css/viewer-main.css
@@ -1,2 +1,2 @@
 /* extracted by css-entry-points-plugin */
-@import './main-DbamWgYd.chunk.css';
+@import './main-DduclpYy.chunk.css';

--- a/js/viewer-main.mjs
+++ b/js/viewer-main.mjs
@@ -27225,7 +27225,8 @@ function pushToHistory({ fileid }) {
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  *
  */
-const client = davGetClient();
+const davRemote = davGetRemoteURL();
+const client = davGetClient(`${davRemote}${davRootPath}`);
 /*! third party licenses: js/vendor.LICENSE.txt */
 /**
  * @copyright Copyright (c) 2019 John Molakvoæ <skjnldsv@protonmail.com>
@@ -28224,9 +28225,6 @@ const _sfc_main$D = {
      * @param {string|null} overrideHandlerId the ID of the handler with which to view the files, if any
      */
     async openFile(path, overrideHandlerId = null) {
-      if (!path.startsWith(davRootPath)) {
-        path = `${davRootPath}${path}`;
-      }
       await this.beforeOpen();
       this.cancelRequestFile();
       if (this.isSameFile(null, path)) {
@@ -28716,7 +28714,7 @@ var __component__$D = /* @__PURE__ */ normalizeComponent$1(
   _sfc_staticRenderFns$D,
   false,
   null,
-  "9bc9aec6"
+  "e16cf4dc"
 );
 const ViewerComponent = __component__$D.exports;
 function setAsyncState(vm, stateObject, state) {

--- a/src/services/WebdavClient.ts
+++ b/src/services/WebdavClient.ts
@@ -20,6 +20,8 @@
  *
  */
 
-import { davGetClient } from '@nextcloud/files'
+import { davGetClient, davRootPath, davGetRemoteURL } from '@nextcloud/files'
 
-export const client = davGetClient()
+const davRemote = davGetRemoteURL()
+
+export const client = davGetClient(`${davRemote}${davRootPath}`)

--- a/src/views/Viewer.vue
+++ b/src/views/Viewer.vue
@@ -599,9 +599,6 @@ export default {
 		 * @param {string|null} overrideHandlerId the ID of the handler with which to view the files, if any
 		 */
 		async openFile(path, overrideHandlerId = null) {
-			if (!path.startsWith(davRootPath)) {
-				path = `${davRootPath}${path}`
-			}
 			await this.beforeOpen()
 
 			// cancel any previous request


### PR DESCRIPTION
@susnux After #2392 and #2414 the filename attribute is still different from before. Before we used to have the relative path based on the user home or public share, how it actually includes the files/userId/ dav root.

My quick fix proposal would be to change the root that the dav client uses so the path it returns for filename is again relative to that root.

We could otherwise of course adjust apps that make use of that path, but I think the path relative to the root is more useful then the full dav path.

Before the refactor: /MyFolder/test.odt
After the refactor: /files/admin/MyFolder/test.odt
After this PR: /MyFolder/test.odt

- [x] Needs cypress to run again on CI #2416 

Test CI runs for text, richdocuments:
- [ ] https://github.com/nextcloud/richdocuments/pull/3900
- [ ] https://github.com/nextcloud/text/pull/6201