### PR TITLE
fix: undefined filename in livephoto

### DIFF
--- a/js/viewer-main.mjs
+++ b/js/viewer-main.mjs
@@ -26978,6 +26978,9 @@ const genFileInfo = function(obj) {
 };
 function getDavPath({ filename, source = "" }) {
   const prefixUser = davRootPath;
+  if (!filename || typeof filename !== "string") {
+    return null;
+  }
   if (source && !source.includes(prefixUser)) {
     return null;
   }

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -125,6 +125,10 @@ function getDavPath({ filename, source = '' }: { filename: string, source?: stri
 	// https://github.com/nextcloud/server/issues/19700
 	const prefixUser = davRootPath
 
+	if (!filename || typeof filename !== 'string') {
+		return null
+	}
+
 	// If we have a source but we're not a dav resource, return null
 	if (source && !source.includes(prefixUser)) {
 		return null


### PR DESCRIPTION
```
TypeError: Cannot read properties of undefined (reading 'startsWith')
    at getDavPath (viewer-main.mjs?v=4627e4c8-1765:27012:16)
    at VueComponent.livePhotoDavPath (viewer-main.mjs?v=46…e4c8-1765:121693:31)
    at Watcher2.get (viewer-main.mjs?v=4627e4c8-1765:2300:30)
    at Watcher2.evaluate (viewer-main.mjs?v=4627e4c8-1765:2371:25)
    at VueComponent.computedGetter [as livePhotoDavPath] (viewer-main.mjs?v=4627e4c8-1765:3561:17)
    at VueComponent.livePhotoSrc (viewer-main.mjs?v=46…e4c8-1765:121689:45)
```

No idea how to properly reproduce this, but I've had reports and experienced it myself