### PR TITLE
fix: Strictify live photo condition to prevent false positive

### DIFF
--- a/css/main-Y8hU2k5s.chunk.css
+++ b/css/main-Y8hU2k5s.chunk.css
@@ -1,0 +1,9334 @@
+@charset "UTF-8";/*!
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+.toastify.dialogs {
+  min-width: 200px;
+  background: none;
+  background-color: var(--color-main-background);
+  color: var(--color-main-text);
+  box-shadow: 0 0 6px 0 var(--color-box-shadow);
+  padding: 0 12px;
+  margin-top: 45px;
+  position: fixed;
+  z-index: 10100;
+  border-radius: var(--border-radius);
+  display: flex;
+  align-items: center;
+}
+.toastify.dialogs .toast-undo-container {
+  display: flex;
+  align-items: center;
+}
+.toastify.dialogs .toast-undo-button,
+.toastify.dialogs .toast-close {
+  position: static;
+  overflow: hidden;
+  box-sizing: border-box;
+  min-width: 44px;
+  height: 100%;
+  padding: 12px;
+  white-space: nowrap;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-color: transparent;
+  min-height: 0;
+}
+.toastify.dialogs .toast-undo-button.toast-close,
+.toastify.dialogs .toast-close.toast-close {
+  text-indent: 0;
+  opacity: 0.4;
+  border: none;
+  min-height: 44px;
+  margin-left: 10px;
+  font-size: 0;
+  /* dark theme overrides for Nextcloud 25 and later */
+}
+.toastify.dialogs .toast-undo-button.toast-close::before,
+.toastify.dialogs .toast-close.toast-close::before {
+  background-image: url("data:image/svg+xml,%3csvg%20viewBox='0%200%2016%2016'%20height='16'%20width='16'%20xmlns='http://www.w3.org/2000/svg'%20xml:space='preserve'%20style='fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2'%3e%3cpath%20d='M6.4%2019%205%2017.6l5.6-5.6L5%206.4%206.4%205l5.6%205.6L17.6%205%2019%206.4%2013.4%2012l5.6%205.6-1.4%201.4-5.6-5.6L6.4%2019Z'%20style='fill-rule:nonzero'%20transform='matrix(.85714%200%200%20.85714%20-2.286%20-2.286)'/%3e%3c/svg%3e");
+  content: " ";
+  filter: var(--background-invert-if-dark);
+  display: inline-block;
+  width: 16px;
+  height: 16px;
+}
+.toastify.dialogs .toast-undo-button.toast-undo-button,
+.toastify.dialogs .toast-close.toast-undo-button {
+  margin: 3px;
+  height: calc(100% - 2 * 3px);
+  margin-left: 12px;
+}
+.toastify.dialogs .toast-undo-button:hover, .toastify.dialogs .toast-undo-button:focus, .toastify.dialogs .toast-undo-button:active,
+.toastify.dialogs .toast-close:hover,
+.toastify.dialogs .toast-close:focus,
+.toastify.dialogs .toast-close:active {
+  cursor: pointer;
+  opacity: 1;
+}
+.toastify.dialogs.toastify-top {
+  right: 10px;
+}
+.toastify.dialogs.toast-with-click {
+  cursor: pointer;
+}
+.toastify.dialogs.toast-error {
+  border-left: 3px solid var(--color-error);
+}
+.toastify.dialogs.toast-info {
+  border-left: 3px solid var(--color-primary);
+}
+.toastify.dialogs.toast-warning {
+  border-left: 3px solid var(--color-warning);
+}
+.toastify.dialogs.toast-success {
+  border-left: 3px solid var(--color-success);
+}
+.toastify.dialogs.toast-undo {
+  border-left: 3px solid var(--color-success);
+}
+
+/* dark theme overrides for Nextcloud 24 and earlier */
+.theme--dark .toastify.dialogs .toast-close {
+  /* close icon style */
+}
+.theme--dark .toastify.dialogs .toast-close.toast-close::before {
+  background-image: url("data:image/svg+xml,%3csvg%20viewBox='0%200%2016%2016'%20height='16'%20width='16'%20xmlns='http://www.w3.org/2000/svg'%20xml:space='preserve'%20style='fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2'%3e%3cpath%20d='M6.4%2019%205%2017.6l5.6-5.6L5%206.4%206.4%205l5.6%205.6L17.6%205%2019%206.4%2013.4%2012l5.6%205.6-1.4%201.4-5.6-5.6L6.4%2019Z'%20style='fill:%23fff;fill-rule:nonzero'%20transform='matrix(.85714%200%200%20.85714%20-2.286%20-2.286)'/%3e%3c/svg%3e");
+}
+.nc-generic-dialog .dialog__actions {
+	justify-content: space-between;
+	min-width: calc(100% - 12px);
+}
+/*!
+ * SPDX-FileCopyrightText: 2023-2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * Icon styling of the file list row preview or fallback icon
+ * (leading icon on the name row and header)
+ */
+._file-picker__file-icon_19mjt_9 {
+  width: 32px;
+  height: 32px;
+  min-width: 32px;
+  min-height: 32px;
+  background-repeat: no-repeat;
+  background-size: contain;
+  display: flex;
+  justify-content: center;
+}/*!
+ * SPDX-FileCopyrightText: 2023-2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+tr.file-picker__row[data-v-15187afc] {
+  height: var(--row-height, 50px);
+}
+tr.file-picker__row td[data-v-15187afc] {
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  border-bottom: none;
+}
+tr.file-picker__row td.row-checkbox[data-v-15187afc] {
+  padding: 0 2px;
+}
+tr.file-picker__row td[data-v-15187afc]:not(.row-checkbox) {
+  padding-inline: 14px 0;
+}
+tr.file-picker__row td.row-size[data-v-15187afc] {
+  text-align: end;
+  padding-inline: 0 14px;
+}
+tr.file-picker__row td.row-name[data-v-15187afc] {
+  padding-inline: 2px 0;
+}
+@keyframes gradient-15187afc {
+0% {
+    background-position: 0% 50%;
+}
+50% {
+    background-position: 100% 50%;
+}
+100% {
+    background-position: 0% 50%;
+}
+}
+.loading-row .row-checkbox[data-v-15187afc] {
+  text-align: center !important;
+}
+.loading-row span[data-v-15187afc] {
+  display: inline-block;
+  height: 24px;
+  background: linear-gradient(to right, var(--color-background-darker), var(--color-text-maxcontrast), var(--color-background-darker));
+  background-size: 600px 100%;
+  border-radius: var(--border-radius);
+  animation: gradient-15187afc 12s ease infinite;
+}
+.loading-row .row-wrapper[data-v-15187afc] {
+  display: inline-flex;
+  align-items: center;
+}
+.loading-row .row-checkbox span[data-v-15187afc] {
+  width: 24px;
+}
+.loading-row .row-name span[data-v-15187afc]:last-of-type {
+  margin-inline-start: 6px;
+  width: 130px;
+}
+.loading-row .row-size span[data-v-15187afc] {
+  width: 80px;
+}
+.loading-row .row-modified span[data-v-15187afc] {
+  width: 90px;
+}/*!
+ * SPDX-FileCopyrightText: 2023-2024 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+tr.file-picker__row[data-v-cb12dccb] {
+  height: var(--row-height, 50px);
+}
+tr.file-picker__row td[data-v-cb12dccb] {
+  cursor: pointer;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  border-bottom: none;
+}
+tr.file-picker__row td.row-checkbox[data-v-cb12dccb] {
+  padding: 0 2px;
+}
+tr.file-picker__row td[data-v-cb12dccb]:not(.row-checkbox) {
+  padding-inline: 14px 0;
+}
+tr.file-picker__row td.row-size[data-v-cb12dccb] {
+  text-align: end;
+  padding-inline: 0 14px;
+}
+tr.file-picker__row td.row-name[data-v-cb12dccb] {
+  padding-inline: 2px 0;
+}
+.file-picker__row--selected[data-v-cb12dccb] {
+  background-color: var(--color-background-dark);
+}
+.file-picker__row[data-v-cb12dccb]:hover {
+  background-color: var(--color-background-hover);
+}
+.file-picker__name-container[data-v-cb12dccb] {
+  display: flex;
+  justify-content: start;
+  align-items: center;
+  height: 100%;
+}
+.file-picker__file-name[data-v-cb12dccb] {
+  padding-inline-start: 6px;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.file-picker__file-extension[data-v-cb12dccb] {
+  color: var(--color-text-maxcontrast);
+  min-width: fit-content;
+}.file-picker__header-preview[data-v-006fdbd0] {
+  width: 22px;
+  height: 32px;
+  flex: 0 0 auto;
+}
+.file-picker__files[data-v-006fdbd0] {
+  margin: 2px;
+  margin-inline-start: 12px;
+  overflow: scroll auto;
+}
+.file-picker__files table[data-v-006fdbd0] {
+  width: 100%;
+  max-height: 100%;
+  table-layout: fixed;
+}
+.file-picker__files th[data-v-006fdbd0] {
+  position: sticky;
+  z-index: 1;
+  top: 0;
+  background-color: var(--color-main-background);
+  padding: 2px;
+}
+.file-picker__files th .header-wrapper[data-v-006fdbd0] {
+  display: flex;
+}
+.file-picker__files th.row-checkbox[data-v-006fdbd0] {
+  width: 44px;
+}
+.file-picker__files th.row-name[data-v-006fdbd0] {
+  width: 230px;
+}
+.file-picker__files th.row-size[data-v-006fdbd0] {
+  width: 100px;
+}
+.file-picker__files th.row-modified[data-v-006fdbd0] {
+  width: 120px;
+}
+.file-picker__files th[data-v-006fdbd0]:not(.row-size) .button-vue__wrapper {
+  justify-content: start;
+  flex-direction: row-reverse;
+}
+.file-picker__files th[data-v-006fdbd0]:not(.row-size) .button-vue {
+  padding-inline: 16px 4px;
+}
+.file-picker__files th.row-size[data-v-006fdbd0] .button-vue__wrapper {
+  justify-content: end;
+}
+.file-picker__files th[data-v-006fdbd0] .button-vue__wrapper {
+  color: var(--color-text-maxcontrast);
+}
+.file-picker__files th[data-v-006fdbd0] .button-vue__wrapper .button-vue__text {
+  font-weight: normal;
+}.file-picker__breadcrumbs[data-v-b357227a] {
+  flex-grow: 0 !important;
+}.file-picker__side[data-v-b42054b8] {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0.5rem;
+  min-width: 200px;
+  padding: 2px;
+  margin-block-start: 7px;
+  overflow: auto;
+}
+.file-picker__side[data-v-b42054b8] .button-vue__wrapper {
+  justify-content: start;
+}
+.file-picker__filter-input[data-v-b42054b8] {
+  margin-block: 7px;
+  max-width: 260px;
+}
+@media (max-width: 736px) {
+.file-picker__side[data-v-b42054b8] {
+    flex-direction: row;
+    min-width: unset;
+}
+}
+@media (max-width: 512px) {
+.file-picker__side[data-v-b42054b8] {
+    flex-direction: row;
+    min-width: unset;
+}
+.file-picker__filter-input[data-v-b42054b8] {
+    max-width: unset;
+}
+}/* Ensure focus outline is visible */
+.file-picker__navigation {
+  padding-inline: 8px 2px;
+}
+.file-picker__navigation, .file-picker__navigation * {
+  box-sizing: border-box;
+}
+.file-picker__navigation .v-select.select {
+  min-width: 220px;
+}
+@media (min-width: 513px) and (max-width: 736px) {
+.file-picker__navigation {
+    gap: 11px;
+}
+}
+@media (max-width: 512px) {
+.file-picker__navigation {
+    flex-direction: column-reverse !important;
+}
+}.file-picker__view[data-v-20b719ba] {
+  height: 50px;
+  display: flex;
+  justify-content: start;
+  align-items: center;
+}
+.file-picker__view h3[data-v-20b719ba] {
+  font-weight: bold;
+  height: fit-content;
+  margin: 0;
+}
+.file-picker__main[data-v-20b719ba] {
+  box-sizing: border-box;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  flex: 1;
+  padding-inline: 2px;
+}
+.file-picker__main *[data-v-20b719ba] {
+  box-sizing: border-box;
+}
+[data-v-20b719ba] .file-picker {
+  height: min(80vh, 800px) !important;
+}
+@media (max-width: 512px) {
+[data-v-20b719ba] .file-picker {
+    height: calc(100% - 16px - var(--default-clickable-area)) !important;
+}
+}
+[data-v-20b719ba] .file-picker__content {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+
+/** When having the small dialog style we override the modal styling so dialogs look more dialog like */
+@media only screen and (max-width: 512px) {
+.dialog__modal .modal-wrapper--small .modal-container {
+    width: fit-content;
+    height: unset;
+    max-height: 90%;
+    position: relative;
+    top: unset;
+    border-radius: var(--border-radius-large);
+}
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-de9f48dc] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.dialog[data-v-de9f48dc] {
+  height: 100%;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  overflow: hidden;
+}
+.dialog__modal[data-v-de9f48dc] .modal-wrapper .modal-container {
+  display: flex !important;
+  padding-block: 4px 0;
+  padding-inline: 12px 0;
+}
+.dialog__modal[data-v-de9f48dc] .modal-wrapper .modal-container__content {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.dialog__wrapper[data-v-de9f48dc] {
+  display: flex;
+  flex-direction: row;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+.dialog__wrapper--collapsed[data-v-de9f48dc] {
+  flex-direction: column;
+}
+.dialog__navigation[data-v-de9f48dc] {
+  display: flex;
+  flex-shrink: 0;
+}
+.dialog__wrapper:not(.dialog__wrapper--collapsed) .dialog__navigation[data-v-de9f48dc] {
+  flex-direction: column;
+  overflow: hidden auto;
+  height: 100%;
+  min-width: 200px;
+  margin-inline-end: 20px;
+}
+.dialog__wrapper.dialog__wrapper--collapsed .dialog__navigation[data-v-de9f48dc] {
+  flex-direction: row;
+  justify-content: space-between;
+  overflow: auto hidden;
+  width: 100%;
+  min-width: 100%;
+}
+.dialog__name[data-v-de9f48dc] {
+  font-size: 21px;
+  text-align: center;
+  height: fit-content;
+  min-height: var(--default-clickable-area);
+  line-height: var(--default-clickable-area);
+  overflow-wrap: break-word;
+  margin-block: 0 12px;
+}
+.dialog__content[data-v-de9f48dc] {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding-inline-end: 12px;
+}
+.dialog__text[data-v-de9f48dc] {
+  padding-block-end: 6px;
+}
+.dialog__actions[data-v-de9f48dc] {
+  box-sizing: border-box;
+  display: flex;
+  gap: 6px;
+  align-content: center;
+  justify-content: end;
+  width: 100%;
+  max-width: 100%;
+  padding-inline: 0 12px;
+  margin-inline: 0;
+  margin-block: 0;
+}
+.dialog__actions[data-v-de9f48dc]:not(:empty) {
+  margin-block: 6px 12px;
+}
+@media only screen and (max-width: 512px) {
+.dialog__name[data-v-de9f48dc] {
+    text-align: start;
+    margin-inline-end: var(--default-clickable-area);
+}
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-1d602fb0] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.modal-mask[data-v-1d602fb0] {
+  position: fixed;
+  z-index: 9998;
+  top: 0;
+  left: 0;
+  display: block;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+}
+.modal-mask--dark[data-v-1d602fb0] {
+  background-color: rgba(0, 0, 0, 0.92);
+}
+.modal-header[data-v-1d602fb0] {
+  position: absolute;
+  z-index: 10001;
+  top: 0;
+  right: 0;
+  left: 0;
+  display: flex !important;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: var(--header-height);
+  overflow: hidden;
+  transition: opacity 250ms, visibility 250ms;
+}
+.modal-header__name[data-v-1d602fb0] {
+  overflow-x: hidden;
+  box-sizing: border-box;
+  width: 100%;
+  padding: 0 calc(var(--default-clickable-area) * 3) 0 12px;
+  transition: padding ease 100ms;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: 16px;
+  margin-block: 0;
+}
+@media only screen and (min-width: 1024px) {
+.modal-header__name[data-v-1d602fb0] {
+    padding-left: calc(var(--default-clickable-area) * 3);
+    text-align: center;
+}
+}
+.modal-header .icons-menu[data-v-1d602fb0] {
+  position: absolute;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+.modal-header .icons-menu .header-close[data-v-1d602fb0] {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  margin: calc((var(--header-height) - var(--default-clickable-area)) / 2);
+  padding: 0;
+}
+.modal-header .icons-menu .play-pause-icons[data-v-1d602fb0] {
+  position: relative;
+  width: var(--header-height);
+  height: var(--header-height);
+  margin: 0;
+  padding: 0;
+  cursor: pointer;
+  border: none;
+  background-color: transparent;
+}
+.modal-header .icons-menu .play-pause-icons:hover .play-pause-icons__play[data-v-1d602fb0],
+.modal-header .icons-menu .play-pause-icons:hover .play-pause-icons__pause[data-v-1d602fb0], .modal-header .icons-menu .play-pause-icons:focus .play-pause-icons__play[data-v-1d602fb0],
+.modal-header .icons-menu .play-pause-icons:focus .play-pause-icons__pause[data-v-1d602fb0] {
+  opacity: 1;
+  border-radius: calc(var(--default-clickable-area) / 2);
+  background-color: rgba(127, 127, 127, 0.25);
+}
+.modal-header .icons-menu .play-pause-icons__play[data-v-1d602fb0], .modal-header .icons-menu .play-pause-icons__pause[data-v-1d602fb0] {
+  box-sizing: border-box;
+  width: var(--default-clickable-area);
+  height: var(--default-clickable-area);
+  margin: calc((var(--header-height) - var(--default-clickable-area)) / 2);
+  cursor: pointer;
+  opacity: 0.7;
+}
+.modal-header .icons-menu[data-v-1d602fb0]  .action-item {
+  margin: calc((var(--header-height) - var(--default-clickable-area)) / 2);
+}
+.modal-header .icons-menu[data-v-1d602fb0]  .action-item--single {
+  box-sizing: border-box;
+  width: var(--default-clickable-area);
+  height: var(--default-clickable-area);
+  cursor: pointer;
+  background-position: center;
+  background-size: 22px;
+}
+.modal-header .icons-menu .header-actions[data-v-1d602fb0] button:focus-visible {
+  box-shadow: none !important;
+  outline: 2px solid #fff !important;
+}
+.modal-header .icons-menu[data-v-1d602fb0] .action-item__menutoggle {
+  padding: 0;
+}
+.modal-header .icons-menu[data-v-1d602fb0] .action-item__menutoggle span, .modal-header .icons-menu[data-v-1d602fb0] .action-item__menutoggle svg {
+  width: var(--icon-size);
+  height: var(--icon-size);
+}
+.modal-wrapper[data-v-1d602fb0] {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  /* Navigation buttons */
+  /* Content */
+}
+.modal-wrapper .prev[data-v-1d602fb0],
+.modal-wrapper .next[data-v-1d602fb0] {
+  z-index: 10000;
+  height: 35vh;
+  min-height: 300px;
+  position: absolute;
+  transition: opacity 250ms;
+  color: white;
+}
+.modal-wrapper .prev[data-v-1d602fb0]:focus-visible,
+.modal-wrapper .next[data-v-1d602fb0]:focus-visible {
+  box-shadow: 0 0 0 2px var(--color-primary-element-text);
+  background-color: var(--color-box-shadow);
+}
+.modal-wrapper .prev[data-v-1d602fb0] {
+  left: 2px;
+}
+.modal-wrapper .next[data-v-1d602fb0] {
+  right: 2px;
+}
+.modal-wrapper .modal-container[data-v-1d602fb0] {
+  position: relative;
+  display: flex;
+  padding: 0;
+  transition: transform 300ms ease;
+  border-radius: var(--border-radius-large);
+  background-color: var(--color-main-background);
+  color: var(--color-main-text);
+  box-shadow: 0 0 40px rgba(0, 0, 0, 0.2);
+}
+.modal-wrapper .modal-container__close[data-v-1d602fb0] {
+  z-index: 1;
+  position: absolute;
+  top: 4px;
+  right: 4px;
+}
+.modal-wrapper .modal-container__content[data-v-1d602fb0] {
+  width: 100%;
+  min-height: 52px;
+  overflow: auto;
+}
+.modal-wrapper--small > .modal-container[data-v-1d602fb0] {
+  width: 400px;
+  max-width: 90%;
+  max-height: min(90%, 100% - 2 * var(--header-height));
+}
+.modal-wrapper--normal > .modal-container[data-v-1d602fb0] {
+  max-width: 90%;
+  width: 600px;
+  max-height: min(90%, 100% - 2 * var(--header-height));
+}
+.modal-wrapper--large > .modal-container[data-v-1d602fb0] {
+  max-width: 90%;
+  width: 900px;
+  max-height: min(90%, 100% - 2 * var(--header-height));
+}
+.modal-wrapper--full > .modal-container[data-v-1d602fb0] {
+  width: 100%;
+  height: calc(100% - var(--header-height));
+  position: absolute;
+  top: var(--header-height);
+  border-radius: 0;
+}
+@media only screen and ((max-width: 512px) or (max-height: 400px)) {
+.modal-wrapper .modal-container[data-v-1d602fb0] {
+    max-width: initial;
+    width: 100%;
+    max-height: initial;
+    height: calc(100% - var(--header-height));
+    position: absolute;
+    top: var(--header-height);
+    border-radius: 0;
+}
+}
+
+/* TRANSITIONS */
+.fade-enter-active[data-v-1d602fb0],
+.fade-leave-active[data-v-1d602fb0] {
+  transition: opacity 250ms;
+}
+.fade-enter[data-v-1d602fb0],
+.fade-leave-to[data-v-1d602fb0] {
+  opacity: 0;
+}
+.fade-visibility-enter[data-v-1d602fb0],
+.fade-visibility-leave-to[data-v-1d602fb0] {
+  visibility: hidden;
+  opacity: 0;
+}
+.modal-in-enter-active[data-v-1d602fb0],
+.modal-in-leave-active[data-v-1d602fb0],
+.modal-out-enter-active[data-v-1d602fb0],
+.modal-out-leave-active[data-v-1d602fb0] {
+  transition: opacity 250ms;
+}
+.modal-in-enter[data-v-1d602fb0],
+.modal-in-leave-to[data-v-1d602fb0],
+.modal-out-enter[data-v-1d602fb0],
+.modal-out-leave-to[data-v-1d602fb0] {
+  opacity: 0;
+}
+.modal-in-enter .modal-container[data-v-1d602fb0],
+.modal-in-leave-to .modal-container[data-v-1d602fb0] {
+  transform: scale(0.9);
+}
+.modal-out-enter .modal-container[data-v-1d602fb0],
+.modal-out-leave-to .modal-container[data-v-1d602fb0] {
+  transform: scale(1.1);
+}
+.modal-mask .play-pause-icons .progress-ring[data-v-1d602fb0] {
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform: rotate(-90deg);
+}
+.modal-mask .play-pause-icons .progress-ring .progress-ring__circle[data-v-1d602fb0] {
+  transition: 100ms stroke-dashoffset;
+  transform-origin: 50% 50%;
+  animation: progressring-1d602fb0 linear var(--slideshow-duration) infinite;
+  stroke-linecap: round;
+  stroke-dashoffset: 94.2477796077;
+  stroke-dasharray: 94.2477796077;
+}
+.modal-mask .play-pause-icons--paused .icon-pause[data-v-1d602fb0] {
+  animation: breath-1d602fb0 2s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+}
+.modal-mask .play-pause-icons--paused .progress-ring__circle[data-v-1d602fb0] {
+  animation-play-state: paused !important;
+}
+@keyframes progressring-1d602fb0 {
+from {
+    stroke-dashoffset: 94.2477796077;
+}
+to {
+    stroke-dashoffset: 0;
+}
+}
+@keyframes breath-1d602fb0 {
+0% {
+    opacity: 1;
+}
+50% {
+    opacity: 0;
+}
+100% {
+    opacity: 1;
+}
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-cc61c052] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.action-items[data-v-cc61c052] {
+  display: flex;
+  align-items: center;
+}
+.action-items > button[data-v-cc61c052] {
+  margin-right: calc((var(--default-clickable-area) - 16px) / 2 / 2);
+}
+.action-item[data-v-cc61c052] {
+  --open-background-color: var(--color-background-hover, $action-background-hover);
+  position: relative;
+  display: inline-block;
+}
+.action-item.action-item--primary[data-v-cc61c052] {
+  --open-background-color: var(--color-primary-element-hover);
+}
+.action-item.action-item--secondary[data-v-cc61c052] {
+  --open-background-color: var(--color-primary-element-light-hover);
+}
+.action-item.action-item--error[data-v-cc61c052] {
+  --open-background-color: var(--color-error-hover);
+}
+.action-item.action-item--warning[data-v-cc61c052] {
+  --open-background-color: var(--color-warning-hover);
+}
+.action-item.action-item--success[data-v-cc61c052] {
+  --open-background-color: var(--color-success-hover);
+}
+.action-item.action-item--tertiary-no-background[data-v-cc61c052] {
+  --open-background-color: transparent;
+}
+.action-item.action-item--open .action-item__menutoggle[data-v-cc61c052] {
+  background-color: var(--open-background-color);
+}
+.action-item__menutoggle__icon[data-v-cc61c052] {
+  width: 20px;
+  height: 20px;
+  object-fit: contain;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.v-popper--theme-dropdown.v-popper__popper.action-item__popper .v-popper__wrapper {
+  border-radius: var(--border-radius-large);
+  overflow: hidden;
+}
+.v-popper--theme-dropdown.v-popper__popper.action-item__popper .v-popper__wrapper .v-popper__inner {
+  border-radius: var(--border-radius-large);
+  padding: 4px;
+  max-height: calc(100vh - var(--header-height));
+  overflow: auto;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-c3d9e0ce] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.button-vue[data-v-c3d9e0ce] {
+  --button-size: var(--default-clickable-area);
+  --button-radius: var(--border-radius-element, calc(var(--button-size) / 2));
+  --button-padding: clamp(var(--default-grid-baseline), var(--button-radius), calc(var(--default-grid-baseline) * 4));
+  position: relative;
+  width: fit-content;
+  overflow: hidden;
+  border: 0;
+  padding: 0;
+  font-size: var(--default-font-size);
+  font-weight: bold;
+  min-height: var(--button-size);
+  min-width: var(--button-size);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  border-radius: var(--button-radius);
+  transition-property: color, border-color, background-color;
+  transition-duration: 0.1s;
+  transition-timing-function: linear;
+  color: var(--color-primary-element-light-text);
+  background-color: var(--color-primary-element-light);
+}
+.button-vue--size-small[data-v-c3d9e0ce] {
+  --button-size: var(--clickable-area-small, 24px);
+  --button-radius: var(--border-radius);
+}
+.button-vue--size-large[data-v-c3d9e0ce] {
+  --button-size: var(--clickable-area-large, 48px);
+}
+.button-vue *[data-v-c3d9e0ce],
+.button-vue span[data-v-c3d9e0ce] {
+  cursor: pointer;
+}
+.button-vue[data-v-c3d9e0ce]:focus {
+  outline: none;
+}
+.button-vue[data-v-c3d9e0ce]:disabled {
+  cursor: default;
+  opacity: 0.5;
+  filter: saturate(0.7);
+}
+.button-vue:disabled *[data-v-c3d9e0ce] {
+  cursor: default;
+}
+.button-vue[data-v-c3d9e0ce]:hover:not(:disabled) {
+  background-color: var(--color-primary-element-light-hover);
+}
+.button-vue[data-v-c3d9e0ce]:active {
+  background-color: var(--color-primary-element-light);
+}
+.button-vue__wrapper[data-v-c3d9e0ce] {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+}
+.button-vue--end .button-vue__wrapper[data-v-c3d9e0ce] {
+  justify-content: end;
+}
+.button-vue--start .button-vue__wrapper[data-v-c3d9e0ce] {
+  justify-content: start;
+}
+.button-vue--reverse .button-vue__wrapper[data-v-c3d9e0ce] {
+  flex-direction: row-reverse;
+}
+.button-vue--reverse.button-vue--icon-and-text[data-v-c3d9e0ce] {
+  padding-inline: var(--button-padding) var(--default-grid-baseline);
+}
+.button-vue__icon[data-v-c3d9e0ce] {
+  height: var(--button-size);
+  width: var(--button-size);
+  min-height: var(--button-size);
+  min-width: var(--button-size);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.button-vue--size-small .button-vue__icon[data-v-c3d9e0ce] > * {
+  max-height: 16px;
+  max-width: 16px;
+}
+.button-vue--size-small .button-vue__icon[data-v-c3d9e0ce] svg {
+  height: 16px;
+  width: 16px;
+}
+.button-vue__text[data-v-c3d9e0ce] {
+  font-weight: bold;
+  margin-bottom: 1px;
+  padding: 2px 0;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+.button-vue--icon-only[data-v-c3d9e0ce] {
+  line-height: 1;
+  width: var(--button-size) !important;
+}
+.button-vue--text-only[data-v-c3d9e0ce] {
+  padding: 0 var(--button-padding);
+}
+.button-vue--text-only .button-vue__text[data-v-c3d9e0ce] {
+  margin-left: 4px;
+  margin-right: 4px;
+}
+.button-vue--icon-and-text[data-v-c3d9e0ce] {
+  --button-padding: min(calc(var(--default-grid-baseline) + var(--button-radius)), calc(var(--default-grid-baseline) * 4));
+  padding-block: 0;
+  padding-inline: var(--default-grid-baseline) var(--button-padding);
+}
+.button-vue--wide[data-v-c3d9e0ce] {
+  width: 100%;
+}
+.button-vue[data-v-c3d9e0ce]:focus-visible {
+  outline: 2px solid var(--color-main-text) !important;
+  box-shadow: 0 0 0 4px var(--color-main-background) !important;
+}
+.button-vue:focus-visible.button-vue--vue-tertiary-on-primary[data-v-c3d9e0ce] {
+  outline: 2px solid var(--color-primary-element-text);
+  border-radius: var(--border-radius-element, var(--border-radius));
+  background-color: transparent;
+}
+.button-vue--vue-primary[data-v-c3d9e0ce] {
+  background-color: var(--color-primary-element);
+  color: var(--color-primary-element-text);
+}
+.button-vue--vue-primary[data-v-c3d9e0ce]:hover:not(:disabled) {
+  background-color: var(--color-primary-element-hover);
+}
+.button-vue--vue-primary[data-v-c3d9e0ce]:active {
+  background-color: var(--color-primary-element);
+}
+.button-vue--vue-secondary[data-v-c3d9e0ce] {
+  color: var(--color-primary-element-light-text);
+  background-color: var(--color-primary-element-light);
+}
+.button-vue--vue-secondary[data-v-c3d9e0ce]:hover:not(:disabled) {
+  color: var(--color-primary-element-light-text);
+  background-color: var(--color-primary-element-light-hover);
+}
+.button-vue--vue-tertiary[data-v-c3d9e0ce] {
+  color: var(--color-main-text);
+  background-color: transparent;
+}
+.button-vue--vue-tertiary[data-v-c3d9e0ce]:hover:not(:disabled) {
+  background-color: var(--color-background-hover);
+}
+.button-vue--vue-tertiary-no-background[data-v-c3d9e0ce] {
+  color: var(--color-main-text);
+  background-color: transparent;
+}
+.button-vue--vue-tertiary-no-background[data-v-c3d9e0ce]:hover:not(:disabled) {
+  background-color: transparent;
+}
+.button-vue--vue-tertiary-on-primary[data-v-c3d9e0ce] {
+  color: var(--color-primary-element-text);
+  background-color: transparent;
+}
+.button-vue--vue-tertiary-on-primary[data-v-c3d9e0ce]:hover:not(:disabled) {
+  background-color: transparent;
+}
+.button-vue--vue-success[data-v-c3d9e0ce] {
+  background-color: var(--color-success);
+  color: white;
+}
+.button-vue--vue-success[data-v-c3d9e0ce]:hover:not(:disabled) {
+  background-color: var(--color-success-hover);
+}
+.button-vue--vue-success[data-v-c3d9e0ce]:active {
+  background-color: var(--color-success);
+}
+.button-vue--vue-warning[data-v-c3d9e0ce] {
+  background-color: var(--color-warning);
+  color: white;
+}
+.button-vue--vue-warning[data-v-c3d9e0ce]:hover:not(:disabled) {
+  background-color: var(--color-warning-hover);
+}
+.button-vue--vue-warning[data-v-c3d9e0ce]:active {
+  background-color: var(--color-warning);
+}
+.button-vue--vue-error[data-v-c3d9e0ce] {
+  background-color: var(--color-error);
+  color: white;
+}
+.button-vue--vue-error[data-v-c3d9e0ce]:hover:not(:disabled) {
+  background-color: var(--color-error-hover);
+}
+.button-vue--vue-error[data-v-c3d9e0ce]:active {
+  background-color: var(--color-error);
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.resize-observer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: -1;
+  width: 100%;
+  height: 100%;
+  border: none;
+  background-color: transparent;
+  pointer-events: none;
+  display: block;
+  overflow: hidden;
+  opacity: 0;
+}
+.resize-observer object {
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: -1;
+}
+.v-popper--theme-dropdown.v-popper__popper {
+  z-index: 100000;
+  top: 0;
+  left: 0;
+  display: block !important;
+  filter: drop-shadow(0 1px 10px var(--color-box-shadow));
+}
+.v-popper--theme-dropdown.v-popper__popper .v-popper__inner {
+  padding: 0;
+  color: var(--color-main-text);
+  border-radius: var(--border-radius-large);
+  overflow: hidden;
+  background: var(--color-main-background);
+}
+.v-popper--theme-dropdown.v-popper__popper .v-popper__arrow-container {
+  position: absolute;
+  z-index: 1;
+  width: 0;
+  height: 0;
+  border-style: solid;
+  border-color: transparent;
+  border-width: 10px;
+}
+.v-popper--theme-dropdown.v-popper__popper[data-popper-placement^=top] .v-popper__arrow-container {
+  bottom: -10px;
+  border-bottom-width: 0;
+  border-top-color: var(--color-main-background);
+}
+.v-popper--theme-dropdown.v-popper__popper[data-popper-placement^=bottom] .v-popper__arrow-container {
+  top: -10px;
+  border-top-width: 0;
+  border-bottom-color: var(--color-main-background);
+}
+.v-popper--theme-dropdown.v-popper__popper[data-popper-placement^=right] .v-popper__arrow-container {
+  left: -10px;
+  border-left-width: 0;
+  border-right-color: var(--color-main-background);
+}
+.v-popper--theme-dropdown.v-popper__popper[data-popper-placement^=left] .v-popper__arrow-container {
+  right: -10px;
+  border-right-width: 0;
+  border-left-color: var(--color-main-background);
+}
+.v-popper--theme-dropdown.v-popper__popper[aria-hidden=true] {
+  visibility: hidden;
+  transition: opacity var(--animation-quick), visibility var(--animation-quick);
+  opacity: 0;
+}
+.v-popper--theme-dropdown.v-popper__popper[aria-hidden=false] {
+  visibility: visible;
+  transition: opacity var(--animation-quick);
+  opacity: 1;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+
+/**
+* SPDX-FileCopyrightText: 2011-2015 Twitter, Inc.
+* SPDX-FileCopyrightText: 2015-2016 Owncloud, Inc.
+* SPDX-FileCopyrightText: 2016-2024 Nextcloud GmbH and Nextcloud contributors
+* SPDX-License-Identifier: MIT
+*/
+.v-popper--theme-tooltip.v-popper__popper {
+  position: absolute;
+  z-index: 100000;
+  top: 0;
+  right: auto;
+  left: auto;
+  display: block;
+  margin: 0;
+  padding: 0;
+  text-align: left;
+  text-align: start;
+  opacity: 0;
+  line-height: 1.6;
+  line-break: auto;
+  filter: drop-shadow(0 1px 10px var(--color-box-shadow));
+}
+.v-popper--theme-tooltip.v-popper__popper[data-popper-placement^=top] .v-popper__arrow-container {
+  bottom: -10px;
+  border-bottom-width: 0;
+  border-top-color: var(--color-main-background);
+}
+.v-popper--theme-tooltip.v-popper__popper[data-popper-placement^=bottom] .v-popper__arrow-container {
+  top: -10px;
+  border-top-width: 0;
+  border-bottom-color: var(--color-main-background);
+}
+.v-popper--theme-tooltip.v-popper__popper[data-popper-placement^=right] .v-popper__arrow-container {
+  right: 100%;
+  border-left-width: 0;
+  border-right-color: var(--color-main-background);
+}
+.v-popper--theme-tooltip.v-popper__popper[data-popper-placement^=left] .v-popper__arrow-container {
+  left: 100%;
+  border-right-width: 0;
+  border-left-color: var(--color-main-background);
+}
+.v-popper--theme-tooltip.v-popper__popper[aria-hidden=true] {
+  visibility: hidden;
+  transition: opacity 0.15s, visibility 0.15s;
+  opacity: 0;
+}
+.v-popper--theme-tooltip.v-popper__popper[aria-hidden=false] {
+  visibility: visible;
+  transition: opacity 0.15s;
+  opacity: 1;
+}
+.v-popper--theme-tooltip .v-popper__inner {
+  max-width: 350px;
+  padding: 5px 8px;
+  text-align: center;
+  color: var(--color-main-text);
+  border-radius: var(--border-radius);
+  background-color: var(--color-main-background);
+}
+.v-popper--theme-tooltip .v-popper__arrow-container {
+  position: absolute;
+  z-index: 1;
+  width: 0;
+  height: 0;
+  margin: 0;
+  border-style: solid;
+  border-color: transparent;
+  border-width: 10px;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-2d0a4d76] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.icon-vue[data-v-2d0a4d76] {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-width: var(--default-clickable-area);
+  min-height: var(--default-clickable-area);
+  opacity: 1;
+}
+.icon-vue--inline[data-v-2d0a4d76] {
+  display: inline-flex;
+  min-width: fit-content;
+  min-height: fit-content;
+  vertical-align: text-bottom;
+}
+.icon-vue[data-v-2d0a4d76] svg {
+  fill: currentColor;
+  width: var(--icon-size, 20px);
+  height: var(--icon-size, 20px);
+  max-width: var(--icon-size, 20px);
+  max-height: var(--icon-size, 20px);
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-7df28e9e] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.notecard[data-v-7df28e9e] {
+  --note-card-icon-size: 20px;
+  --note-card-padding: calc(2 * var(--default-grid-baseline));
+  color: var(--color-main-text) !important;
+  background-color: var(--note-background) !important;
+  border-inline-start: var(--default-grid-baseline) solid var(--note-theme);
+  border-radius: var(--border-radius);
+  margin: 1rem 0;
+  padding: var(--note-card-padding);
+  display: flex;
+  flex-direction: row;
+  gap: var(--note-card-padding);
+}
+.notecard__heading[data-v-7df28e9e] {
+  font-size: var(--note-card-icon-size);
+  font-weight: 600;
+}
+.notecard__icon--heading[data-v-7df28e9e] {
+  font-size: var(--note-card-icon-size);
+  margin-block: calc((1lh - 1em) / 2) auto;
+}
+.notecard--success[data-v-7df28e9e] {
+  --note-background: rgba(var(--color-success-rgb), 0.1);
+  --note-theme: var(--color-success);
+}
+.notecard--info[data-v-7df28e9e] {
+  --note-background: rgba(var(--color-info-rgb), 0.1);
+  --note-theme: var(--color-info);
+}
+.notecard--error[data-v-7df28e9e] {
+  --note-background: rgba(var(--color-error-rgb), 0.1);
+  --note-theme: var(--color-error);
+}
+.notecard--warning[data-v-7df28e9e] {
+  --note-background: rgba(var(--color-warning-rgb), 0.1);
+  --note-theme: var(--color-warning);
+}
+#emptycontent[data-v-23ff8610] {
+	margin: 0;
+	padding: 10% 5%;
+	background-color: var(--color-main-background);
+}
+.viewer.modal-mask[data-v-123bd91f] {
+  transition: width ease 100ms, background-color 0.3s ease;
+}
+.viewer[data-v-123bd91f] .modal-container, .viewer__content[data-v-123bd91f] {
+  overflow: visible !important;
+  cursor: pointer;
+}
+.viewer--split .viewer__file--active[data-v-123bd91f] {
+  width: 50%;
+}
+.viewer[data-v-123bd91f] .modal-wrapper .modal-container {
+  top: var(--header-height);
+  bottom: var(--header-height);
+  height: auto;
+  background-color: transparent;
+  box-shadow: none;
+}
+.viewer__content[data-v-123bd91f] {
+  width: 100%;
+  height: 100%;
+}
+.viewer__file-wrapper[data-v-123bd91f] {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+}
+.viewer__file-wrapper--hidden[data-v-123bd91f] {
+  position: absolute;
+  z-index: -1;
+  left: -10000px;
+}
+.viewer__file[data-v-123bd91f] {
+  transition: height 100ms ease, width 100ms ease;
+}
+.viewer.theme--dark[data-v-123bd91f] .button-vue--vue-tertiary:hover {
+  background-color: rgba(255, 255, 255, 0.08) !important;
+}
+.viewer.theme--dark[data-v-123bd91f] .button-vue--vue-tertiary:focus, .viewer.theme--dark[data-v-123bd91f] .button-vue--vue-tertiary:focus-visible {
+  background-color: rgba(255, 255, 255, 0.08) !important;
+  outline: 2px solid var(--color-primary-element) !important;
+}
+.viewer.theme--dark[data-v-123bd91f] .button-vue--vue-tertiary.action-item__menutoggle {
+  background-color: transparent;
+}
+.viewer.theme--undefined.modal-mask[data-v-123bd91f] {
+  background-color: transparent !important;
+}
+.viewer.theme--light.modal-mask[data-v-123bd91f] {
+  background-color: rgba(255, 255, 255, 0.92) !important;
+}
+.viewer.theme--light[data-v-123bd91f] .modal-header__name,
+.viewer.theme--light[data-v-123bd91f] .modal-header .icons-menu button svg {
+  color: #000 !important;
+}
+.viewer.theme--default.modal-mask[data-v-123bd91f] {
+  background-color: var(--color-main-background) !important;
+}
+.viewer.theme--default[data-v-123bd91f] .modal-header__name,
+.viewer.theme--default[data-v-123bd91f] .modal-header .icons-menu {
+  color: var(--color-main-text) !important;
+}
+.viewer.theme--default[data-v-123bd91f] .modal-header__name button svg, .viewer.theme--default[data-v-123bd91f] .modal-header__name a,
+.viewer.theme--default[data-v-123bd91f] .modal-header .icons-menu button svg,
+.viewer.theme--default[data-v-123bd91f] .modal-header .icons-menu a {
+  color: var(--color-main-text) !important;
+}
+.viewer.image--fullscreen[data-v-123bd91f] .modal-header .modal-header__name {
+  opacity: 0;
+}
+.viewer.image--fullscreen[data-v-123bd91f] .modal-header .icons-menu {
+  background-color: rgba(0, 0, 0, 0.2);
+}
+.viewer.image--fullscreen[data-v-123bd91f] .modal-wrapper .modal-container {
+  top: 0;
+  bottom: 0;
+  height: 100%;
+}.component-fade-enter-active,
+.component-fade-leave-active {
+  transition: opacity 0.3s ease;
+}
+.component-fade-enter, .component-fade-leave-to {
+  opacity: 0;
+}
+#viewer.modal-mask--dark .action-item--single.icon-menu-sidebar {
+  background-image: url("data:image/svg+xml,%3csvg%20xmlns='http://www.w3.org/2000/svg'%20height='16'%20width='16'%20version='1.1'%20viewbox='0%200%2016%2016'%3e%3cpath%20d='m2%202c-0.554%200-1%200.446-1%201s0.446%201%201%201h12c0.554%200%201-0.446%201-1s-0.446-1-1-1h-12zm9.717%204.0059c-1.247%200-2.1428%201.0199-2.1428%201.998%200%200.9995%200.0726%201.7127%200.5718%202.4981%200.16%200.207%200.347%200.251%200.5%200.43%200.097%200.357%200.171%200.713%200.071%201.07-0.311%200.109-0.607%200.237-0.9065%200.357-0.364-0.195-0.7863-0.357-1.1503-0.5-0.05-0.2-0.0129-0.347%200.0371-0.535%200.0856-0.089%200.163-0.129%200.2558-0.215%200.2642-0.321%200.2793-0.864%200.2793-1.2496%200-0.5712-0.5135-0.9981-1.0703-0.9981-0.6211%200-1.0723%200.5126-1.0723%200.9981h-0.0136c0%200.4996%200.0353%200.8576%200.2851%201.2496%200.0714%200.107%200.1729%200.126%200.25%200.215%200.0481%200.179%200.0859%200.357%200.0352%200.535-0.4569%200.16-0.8863%200.357-1.2832%200.571-0.2999%200.214-0.1668%200.131-0.3574%200.822-0.0886%200.357%200.928%200.521%201.6562%200.578-0.0357%200.196-0.0857%200.457-0.2285%200.957-0.2285%200.893%203.1074%201.213%204.2834%201.213%201.735%200%204.507-0.325%204.269-1.213-0.371-1.385-0.15-1.221-0.701-1.642-0.778-0.467-1.749-0.834-2.568-1.143-0.107-0.398-0.03-0.692%200.07-1.07%200.168-0.179%200.357-0.259%200.514-0.43%200.492-0.6312%200.556-1.7299%200.556-2.4981%200-1.1323-1.019-1.998-2.14-1.998zm-9.717%200.9941c-0.554%200-1%200.446-1%201s0.446%201%201%201h4.2852c0.0891-0.1855%200.2-0.3648%200.3515-0.5195%200.3721-0.3801%200.9171-0.5988%201.4883-0.6192h0.0098%200.0097c0.1729%200.017%200.3042%200.0597%200.4297%200.1426%200-0.3488%200.0747-0.6853%200.1953-1.0039h-6.7695zm0%205c-0.554%200-1%200.446-1%201s0.446%201%201%201h3.25c-0.0375-0.049-0.0777-0.09-0.1113-0.152-0.1221-0.228-0.1706-0.568-0.1035-0.838l0.0019-0.012%200.0039-0.012c0.0822-0.298%200.0556-0.322%200.1445-0.615%200.0313-0.103%200.1114-0.245%200.1993-0.371h-3.3848z'%20fill='%23fff'/%3e%3c/svg%3e");
+}
+#viewer.modal-mask--dark .action-item--single.icon-download {
+  background-image: var(--icon-download-fff);
+}
+.ui-autocomplete {
+  z-index: 2050 !important;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-a92ab385] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.widget--list[data-v-a92ab385] {
+  width: var(--widget-full-width, 100%);
+}
+.widgets--list.icon-loading[data-v-a92ab385] {
+  min-height: var(--default-clickable-area);
+}
+/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-3b61be27] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+/* stylelint-disable-next-line scss/at-import-partial-extension */
+/**
+ * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+* Styles are extracted to extract scss to dist folder, too.
+*/
+li.task-list-item > ul[data-v-3b61be27],
+li.task-list-item > ol[data-v-3b61be27],
+li.task-list-item > li[data-v-3b61be27],
+li.task-list-item > blockquote[data-v-3b61be27],
+li.task-list-item > pre[data-v-3b61be27] {
+  margin-inline-start: 15px;
+  margin-block-end: 0;
+}
+.rich-text--wrapper[data-v-3b61be27] {
+  word-break: break-word;
+  line-height: 1.5;
+}
+.rich-text--wrapper .rich-text--fallback[data-v-3b61be27], .rich-text--wrapper .rich-text-component[data-v-3b61be27] {
+  display: inline;
+}
+.rich-text--wrapper .rich-text--external-link[data-v-3b61be27] {
+  text-decoration: underline;
+}
+.rich-text--wrapper .rich-text--external-link[data-v-3b61be27]:after {
+  content: " ↗";
+}
+.rich-text--wrapper .rich-text--ordered-list .rich-text--list-item[data-v-3b61be27] {
+  list-style: decimal;
+}
+.rich-text--wrapper .rich-text--un-ordered-list .rich-text--list-item[data-v-3b61be27] {
+  list-style: initial;
+}
+.rich-text--wrapper .rich-text--list-item[data-v-3b61be27] {
+  white-space: initial;
+  color: var(--color-text-light);
+  padding: initial;
+  margin-left: 20px;
+}
+.rich-text--wrapper .rich-text--list-item.task-list-item[data-v-3b61be27] {
+  list-style: none;
+  white-space: initial;
+  color: var(--color-text-light);
+}
+.rich-text--wrapper .rich-text--list-item.task-list-item input[data-v-3b61be27] {
+  min-height: initial;
+}
+.rich-text--wrapper .rich-text--strong[data-v-3b61be27] {
+  white-space: initial;
+  font-weight: bold;
+  color: var(--color-text-light);
+}
+.rich-text--wrapper .rich-text--italic[data-v-3b61be27] {
+  white-space: initial;
+  font-style: italic;
+  color: var(--color-text-light);
+}
+.rich-text--wrapper .rich-text--heading[data-v-3b61be27] {
+  white-space: initial;
+  font-size: initial;
+  color: var(--color-text-light);
+  margin-bottom: 5px;
+  margin-top: 5px;
+  font-weight: bold;
+}
+.rich-text--wrapper .rich-text--heading.rich-text--heading-1[data-v-3b61be27] {
+  font-size: 20px;
+}
+.rich-text--wrapper .rich-text--heading.rich-text--heading-2[data-v-3b61be27] {
+  font-size: 19px;
+}
+.rich-text--wrapper .rich-text--heading.rich-text--heading-3[data-v-3b61be27] {
+  font-size: 18px;
+}
+.rich-text--wrapper .rich-text--heading.rich-text--heading-4[data-v-3b61be27] {
+  font-size: 17px;
+}
+.rich-text--wrapper .rich-text--heading.rich-text--heading-5[data-v-3b61be27] {
+  font-size: 16px;
+}
+.rich-text--wrapper .rich-text--heading.rich-text--heading-6[data-v-3b61be27] {
+  font-size: 15px;
+}
+.rich-text--wrapper .rich-text--hr[data-v-3b61be27] {
+  border-top: 1px solid var(--color-border-dark);
+  border-bottom: 0;
+}
+.rich-text--wrapper .rich-text--pre[data-v-3b61be27] {
+  border: 1px solid var(--color-border-dark);
+  background-color: var(--color-background-dark);
+  padding: 5px;
+}
+.rich-text--wrapper .rich-text--code[data-v-3b61be27] {
+  background-color: var(--color-background-dark);
+}
+.rich-text--wrapper .rich-text--blockquote[data-v-3b61be27] {
+  border-left: 3px solid var(--color-border-dark);
+  padding-left: 5px;
+}
+.rich-text--wrapper .rich-text--table[data-v-3b61be27] {
+  border-collapse: collapse;
+}
+.rich-text--wrapper .rich-text--table thead tr th[data-v-3b61be27] {
+  border: 1px solid var(--color-border-dark);
+  font-weight: bold;
+  padding: 6px 13px;
+}
+.rich-text--wrapper .rich-text--table tbody tr td[data-v-3b61be27] {
+  border: 1px solid var(--color-border-dark);
+  padding: 6px 13px;
+}
+.rich-text--wrapper .rich-text--table tbody tr[data-v-3b61be27]:nth-child(even) {
+  background-color: var(--color-background-dark);
+}
+.rich-text--wrapper-markdown div > *[data-v-3b61be27]:first-child,
+.rich-text--wrapper-markdown blockquote > *[data-v-3b61be27]:first-child {
+  margin-top: 0 !important;
+}
+.rich-text--wrapper-markdown div > *[data-v-3b61be27]:last-child,
+.rich-text--wrapper-markdown blockquote > *[data-v-3b61be27]:last-child {
+  margin-bottom: 0 !important;
+}
+.rich-text--wrapper-markdown h1[data-v-3b61be27], .rich-text--wrapper-markdown h2[data-v-3b61be27], .rich-text--wrapper-markdown h3[data-v-3b61be27], .rich-text--wrapper-markdown h4[data-v-3b61be27], .rich-text--wrapper-markdown h5[data-v-3b61be27], .rich-text--wrapper-markdown h6[data-v-3b61be27], .rich-text--wrapper-markdown p[data-v-3b61be27], .rich-text--wrapper-markdown ul[data-v-3b61be27], .rich-text--wrapper-markdown ol[data-v-3b61be27], .rich-text--wrapper-markdown blockquote[data-v-3b61be27], .rich-text--wrapper-markdown pre[data-v-3b61be27] {
+  margin-top: 0;
+  margin-bottom: 1em;
+}
+.rich-text--wrapper-markdown h1[data-v-3b61be27], .rich-text--wrapper-markdown h2[data-v-3b61be27], .rich-text--wrapper-markdown h3[data-v-3b61be27], .rich-text--wrapper-markdown h4[data-v-3b61be27], .rich-text--wrapper-markdown h5[data-v-3b61be27], .rich-text--wrapper-markdown h6[data-v-3b61be27] {
+  font-weight: bold;
+}
+.rich-text--wrapper-markdown h1[data-v-3b61be27] {
+  font-size: 30px;
+}
+.rich-text--wrapper-markdown ul[data-v-3b61be27], .rich-text--wrapper-markdown ol[data-v-3b61be27] {
+  padding-left: 15px;
+}
+.rich-text--wrapper-markdown ul[data-v-3b61be27] {
+  list-style-type: disc;
+}
+.rich-text--wrapper-markdown ul.contains-task-list[data-v-3b61be27] {
+  list-style-type: none;
+  padding: 0;
+}
+.rich-text--wrapper-markdown table[data-v-3b61be27] {
+  border-collapse: collapse;
+  border: 2px solid var(--color-border-maxcontrast);
+}
+.rich-text--wrapper-markdown table th[data-v-3b61be27],
+.rich-text--wrapper-markdown table td[data-v-3b61be27] {
+  padding: var(--default-grid-baseline);
+  border: 1px solid var(--color-border-maxcontrast);
+}
+.rich-text--wrapper-markdown table th[data-v-3b61be27]:first-child,
+.rich-text--wrapper-markdown table td[data-v-3b61be27]:first-child {
+  border-left: 0;
+}
+.rich-text--wrapper-markdown table th[data-v-3b61be27]:last-child,
+.rich-text--wrapper-markdown table td[data-v-3b61be27]:last-child {
+  border-right: 0;
+}
+.rich-text--wrapper-markdown table tr:first-child th[data-v-3b61be27] {
+  border-top: 0;
+}
+.rich-text--wrapper-markdown table tr:last-child td[data-v-3b61be27] {
+  border-bottom: 0;
+}
+.rich-text--wrapper-markdown blockquote[data-v-3b61be27] {
+  padding-left: 13px;
+  border-left: 2px solid var(--color-border-dark);
+  color: var(--color-text-lighter);
+}
+a[data-v-3b61be27]:not(.rich-text--component) {
+  text-decoration: underline;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-dba65098] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+li.action.active[data-v-dba65098] {
+  background-color: var(--color-background-hover);
+  border-radius: 6px;
+  padding: 0;
+}
+.action--disabled[data-v-dba65098] {
+  pointer-events: none;
+  opacity: 0.5;
+}
+.action--disabled[data-v-dba65098]:hover, .action--disabled[data-v-dba65098]:focus {
+  cursor: default;
+  opacity: 0.5;
+}
+.action--disabled *[data-v-dba65098] {
+  opacity: 1 !important;
+}
+.action-button[data-v-dba65098] {
+  display: flex;
+  align-items: flex-start;
+  width: 100%;
+  height: auto;
+  margin: 0;
+  padding: 0;
+  padding-right: calc((var(--default-clickable-area) - 16px) / 2);
+  box-sizing: border-box;
+  cursor: pointer;
+  white-space: nowrap;
+  color: var(--color-main-text);
+  border: 0;
+  border-radius: 0;
+  background-color: transparent;
+  box-shadow: none;
+  font-weight: normal;
+  font-size: var(--default-font-size);
+  line-height: var(--default-clickable-area);
+}
+.action-button > span[data-v-dba65098] {
+  cursor: pointer;
+  white-space: nowrap;
+}
+.action-button__icon[data-v-dba65098] {
+  width: var(--default-clickable-area);
+  height: var(--default-clickable-area);
+  opacity: 1;
+  background-position: calc((var(--default-clickable-area) - 16px) / 2) center;
+  background-size: 16px;
+  background-repeat: no-repeat;
+}
+.action-button[data-v-dba65098] .material-design-icon {
+  width: var(--default-clickable-area);
+  height: var(--default-clickable-area);
+  opacity: 1;
+}
+.action-button[data-v-dba65098] .material-design-icon .material-design-icon__svg {
+  vertical-align: middle;
+}
+.action-button__longtext-wrapper[data-v-dba65098], .action-button__longtext[data-v-dba65098] {
+  max-width: 220px;
+  line-height: 1.6em;
+  padding: calc((var(--default-clickable-area) - 1.6em) / 2) 0;
+  cursor: pointer;
+  text-align: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.action-button__longtext[data-v-dba65098] {
+  cursor: pointer;
+  white-space: pre-wrap !important;
+}
+.action-button__name[data-v-dba65098] {
+  font-weight: bold;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  max-width: 100%;
+  display: inline-block;
+}
+.action-button__menu-icon[data-v-dba65098] {
+  margin-left: auto;
+  margin-right: calc((var(--default-clickable-area) - 16px) / 2 * -1);
+}
+.action-button__pressed-icon[data-v-dba65098] {
+  margin-left: auto;
+  margin-right: calc((var(--default-clickable-area) - 16px) / 2 * -1);
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.nc-button-group-base > div {
+  text-align: center;
+  color: var(--color-text-maxcontrast);
+}
+.nc-button-group-base ul.nc-button-group-content {
+  display: flex;
+  gap: 4px;
+  justify-content: space-between;
+}
+.nc-button-group-base ul.nc-button-group-content li {
+  flex: 1 1;
+}
+.nc-button-group-base ul.nc-button-group-content .action-button {
+  padding: 0 !important;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+.nc-button-group-base ul.nc-button-group-content .action-button.action-button--active {
+  background-color: var(--color-primary-element);
+  border-radius: var(--border-radius-large);
+  color: var(--color-primary-element-text);
+}
+.nc-button-group-base ul.nc-button-group-content .action-button.action-button--active:hover, .nc-button-group-base ul.nc-button-group-content .action-button.action-button--active:focus, .nc-button-group-base ul.nc-button-group-content .action-button.action-button--active:focus-within {
+  background-color: var(--color-primary-element-hover);
+}
+.nc-button-group-base ul.nc-button-group-content .action-button .action-button__pressed-icon {
+  display: none;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-b9668c9e] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.app-navigation-caption[data-v-b9668c9e] {
+  color: var(--color-text-maxcontrast);
+  line-height: var(--default-clickable-area);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  box-shadow: none !important;
+  user-select: none;
+  pointer-events: none;
+  margin-left: 12px;
+  padding-right: 14px;
+  height: var(--default-clickable-area);
+  display: flex;
+  align-items: center;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-1a743a21] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+li.action.active[data-v-1a743a21] {
+  background-color: var(--color-background-hover);
+  border-radius: 6px;
+  padding: 0;
+}
+.action--disabled[data-v-1a743a21] {
+  pointer-events: none;
+  opacity: 0.5;
+}
+.action--disabled[data-v-1a743a21]:hover, .action--disabled[data-v-1a743a21]:focus {
+  cursor: default;
+  opacity: 0.5;
+}
+.action--disabled *[data-v-1a743a21] {
+  opacity: 1 !important;
+}
+.action-checkbox[data-v-1a743a21] {
+  display: flex;
+  align-items: flex-start;
+  width: 100%;
+  height: auto;
+  margin: 0;
+  padding: 0;
+  cursor: pointer;
+  white-space: nowrap;
+  color: var(--color-main-text);
+  border: 0;
+  border-radius: 0;
+  background-color: transparent;
+  box-shadow: none;
+  font-weight: normal;
+  line-height: var(--default-clickable-area);
+  /* checkbox/radio fixes */
+}
+.action-checkbox__checkbox[data-v-1a743a21] {
+  position: absolute;
+  top: auto;
+  left: -10000px;
+  overflow: hidden;
+  width: 1px;
+  height: 1px;
+}
+.action-checkbox__label[data-v-1a743a21] {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 0 !important;
+  padding-right: calc((var(--default-clickable-area) - 16px) / 2) !important;
+}
+.action-checkbox__label[data-v-1a743a21]::before {
+  margin-block: 0 !important;
+  margin-inline: calc((var(--default-clickable-area) - 14px) / 2) !important;
+}
+.action-checkbox--disabled[data-v-1a743a21],
+.action-checkbox--disabled .action-checkbox__label[data-v-1a743a21] {
+  cursor: pointer;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-6ba44c48] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * color-text-lighter		normal state
+ * color-text-lighter		active state
+ * color-text-maxcontrast 	disabled state
+ */
+/* Default global values */
+button[data-v-6ba44c48]:not(.button-vue),
+input[data-v-6ba44c48]:not([type=range]),
+textarea[data-v-6ba44c48] {
+  margin: 0;
+  padding: 7px 6px;
+  cursor: text;
+  color: var(--color-text-lighter);
+  border: 1px solid var(--color-border-dark);
+  border-radius: var(--border-radius);
+  outline: none;
+  background-color: var(--color-main-background);
+  font-size: 13px;
+  /* Primary action button, use sparingly */
+}
+button[data-v-6ba44c48]:not(.button-vue):not(:disabled):not(.primary):hover, button[data-v-6ba44c48]:not(.button-vue):not(:disabled):not(.primary):focus, button:not(.button-vue):not(:disabled):not(.primary).active[data-v-6ba44c48],
+input[data-v-6ba44c48]:not([type=range]):not(:disabled):not(.primary):hover,
+input[data-v-6ba44c48]:not([type=range]):not(:disabled):not(.primary):focus,
+input:not([type=range]):not(:disabled):not(.primary).active[data-v-6ba44c48],
+textarea[data-v-6ba44c48]:not(:disabled):not(.primary):hover,
+textarea[data-v-6ba44c48]:not(:disabled):not(.primary):focus,
+textarea:not(:disabled):not(.primary).active[data-v-6ba44c48] {
+  /* active class used for multiselect */
+  border-color: var(--color-primary-element);
+  outline: none;
+}
+button[data-v-6ba44c48]:not(.button-vue):not(:disabled):not(.primary):active,
+input[data-v-6ba44c48]:not([type=range]):not(:disabled):not(.primary):active,
+textarea[data-v-6ba44c48]:not(:disabled):not(.primary):active {
+  color: var(--color-text-light);
+  outline: none;
+  background-color: var(--color-main-background);
+}
+button[data-v-6ba44c48]:not(.button-vue):disabled,
+input[data-v-6ba44c48]:not([type=range]):disabled,
+textarea[data-v-6ba44c48]:disabled {
+  cursor: default;
+  opacity: 0.5;
+  color: var(--color-text-maxcontrast);
+  background-color: var(--color-background-dark);
+}
+button[data-v-6ba44c48]:not(.button-vue):required,
+input[data-v-6ba44c48]:not([type=range]):required,
+textarea[data-v-6ba44c48]:required {
+  box-shadow: none;
+}
+button[data-v-6ba44c48]:not(.button-vue):invalid,
+input[data-v-6ba44c48]:not([type=range]):invalid,
+textarea[data-v-6ba44c48]:invalid {
+  border-color: var(--color-error);
+  box-shadow: none !important;
+}
+button:not(.button-vue).primary[data-v-6ba44c48],
+input:not([type=range]).primary[data-v-6ba44c48],
+textarea.primary[data-v-6ba44c48] {
+  cursor: pointer;
+  color: var(--color-primary-element-text);
+  border-color: var(--color-primary-element);
+  background-color: var(--color-primary-element);
+}
+button:not(.button-vue).primary[data-v-6ba44c48]:not(:disabled):hover, button:not(.button-vue).primary[data-v-6ba44c48]:not(:disabled):focus, button:not(.button-vue).primary[data-v-6ba44c48]:not(:disabled):active,
+input:not([type=range]).primary[data-v-6ba44c48]:not(:disabled):hover,
+input:not([type=range]).primary[data-v-6ba44c48]:not(:disabled):focus,
+input:not([type=range]).primary[data-v-6ba44c48]:not(:disabled):active,
+textarea.primary[data-v-6ba44c48]:not(:disabled):hover,
+textarea.primary[data-v-6ba44c48]:not(:disabled):focus,
+textarea.primary[data-v-6ba44c48]:not(:disabled):active {
+  border-color: var(--color-primary-element-light);
+  background-color: var(--color-primary-element-light);
+}
+button:not(.button-vue).primary[data-v-6ba44c48]:not(:disabled):active,
+input:not([type=range]).primary[data-v-6ba44c48]:not(:disabled):active,
+textarea.primary[data-v-6ba44c48]:not(:disabled):active {
+  color: var(--color-primary-element-text-dark);
+}
+button:not(.button-vue).primary[data-v-6ba44c48]:disabled,
+input:not([type=range]).primary[data-v-6ba44c48]:disabled,
+textarea.primary[data-v-6ba44c48]:disabled {
+  cursor: default;
+  color: var(--color-primary-element-text-dark);
+  background-color: var(--color-primary-element);
+}
+/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+li.action.active[data-v-6ba44c48] {
+  background-color: var(--color-background-hover);
+  border-radius: 6px;
+  padding: 0;
+}
+.action--disabled[data-v-6ba44c48] {
+  pointer-events: none;
+  opacity: 0.5;
+}
+.action--disabled[data-v-6ba44c48]:hover, .action--disabled[data-v-6ba44c48]:focus {
+  cursor: default;
+  opacity: 0.5;
+}
+.action--disabled *[data-v-6ba44c48] {
+  opacity: 1 !important;
+}
+.action-input[data-v-6ba44c48] {
+  display: flex;
+  align-items: flex-start;
+  width: 100%;
+  height: auto;
+  margin: 0;
+  padding: 0;
+  cursor: pointer;
+  white-space: nowrap;
+  color: var(--color-main-text);
+  border: 0;
+  border-radius: 0;
+  background-color: transparent;
+  box-shadow: none;
+  font-weight: normal;
+}
+.action-input__icon-wrapper[data-v-6ba44c48] {
+  display: flex;
+  align-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.action-input__icon-wrapper[data-v-6ba44c48] .material-design-icon {
+  width: var(--default-clickable-area);
+  height: var(--default-clickable-area);
+  opacity: 1;
+}
+.action-input__icon-wrapper[data-v-6ba44c48] .material-design-icon .material-design-icon__svg {
+  vertical-align: middle;
+}
+.action-input > span[data-v-6ba44c48] {
+  cursor: pointer;
+  white-space: nowrap;
+}
+.action-input__icon[data-v-6ba44c48] {
+  min-width: 0; /* Overwrite icons*/
+  min-height: 0;
+  padding: calc(var(--default-clickable-area) / 2) 0 calc(var(--default-clickable-area) / 2) var(--default-clickable-area);
+  background-position: calc((var(--default-clickable-area) - 16px) / 2) center;
+  background-size: 16px;
+}
+.action-input__form[data-v-6ba44c48] {
+  display: flex;
+  align-items: center;
+  flex: 1 1 auto;
+  margin: 4px 0;
+  padding-right: calc((var(--default-clickable-area) - 16px) / 2);
+}
+.action-input__container[data-v-6ba44c48] {
+  width: 100%;
+}
+.action-input__input-container[data-v-6ba44c48] {
+  display: flex;
+}
+.action-input__input-container .colorpicker__trigger[data-v-6ba44c48], .action-input__input-container .colorpicker__preview[data-v-6ba44c48] {
+  width: 100%;
+}
+.action-input__input-container .colorpicker__preview[data-v-6ba44c48] {
+  width: 100%;
+  height: 36px;
+  border-radius: var(--border-radius-large);
+  border: 2px solid var(--color-border-maxcontrast);
+  box-shadow: none !important;
+}
+.action-input__text-label[data-v-6ba44c48] {
+  padding: 4px 0;
+  display: block;
+}
+.action-input__text-label--hidden[data-v-6ba44c48] {
+  position: absolute;
+  left: -10000px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+.action-input__datetimepicker[data-v-6ba44c48] {
+  width: 100%;
+}
+.action-input__datetimepicker[data-v-6ba44c48] .mx-input {
+  margin: 0;
+}
+.action-input__multi[data-v-6ba44c48] {
+  width: 100%;
+}
+li:last-child > .action-input[data-v-6ba44c48] {
+  padding-bottom: calc((var(--default-clickable-area) - 16px) / 2 - 4px);
+}
+li:first-child > .action-input[data-v-6ba44c48]:not(.action-input--visible-label) {
+  padding-top: calc((var(--default-clickable-area) - 16px) / 2 - 4px);
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+/**
+* SPDX-FileCopyrightText: 2020 Nextcloud GmbH and Nextcloud contributors
+* SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+.mx-icon-left:before,
+.mx-icon-right:before,
+.mx-icon-double-left:before,
+.mx-icon-double-right:before,
+.mx-icon-double-left:after,
+.mx-icon-double-right:after {
+  content: "";
+  position: relative;
+  top: -1px;
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  vertical-align: middle;
+  border-style: solid;
+  border-color: currentColor;
+  border-width: 2px 0 0 2px;
+  border-radius: 1px;
+  box-sizing: border-box;
+  transform-origin: center;
+  transform: rotate(-45deg) scale(0.7);
+}
+.mx-icon-double-left:after {
+  left: -4px;
+}
+.mx-icon-double-right:before {
+  left: 4px;
+}
+.mx-icon-right:before,
+.mx-icon-double-right:before,
+.mx-icon-double-right:after {
+  transform: rotate(135deg) scale(0.7);
+}
+.mx-btn {
+  box-sizing: border-box;
+  line-height: 1;
+  font-size: 14px;
+  font-weight: 500;
+  padding: 7px 15px;
+  margin: 0;
+  cursor: pointer;
+  background-color: transparent;
+  outline: none;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 4px;
+  color: #73879c;
+  white-space: nowrap;
+}
+.mx-btn:hover {
+  border-color: #1284e7;
+  color: #1284e7;
+}
+.mx-btn:disabled, .mx-btn.disabled {
+  color: #ccc;
+  cursor: not-allowed;
+}
+.mx-btn-text {
+  border: 0;
+  padding: 0 4px;
+  text-align: left;
+  line-height: inherit;
+}
+.mx-scrollbar {
+  height: 100%;
+}
+.mx-scrollbar:hover .mx-scrollbar-track {
+  opacity: 1;
+}
+.mx-scrollbar-wrap {
+  height: 100%;
+  overflow-x: hidden;
+  overflow-y: auto;
+}
+.mx-scrollbar-track {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  bottom: 2px;
+  width: 6px;
+  z-index: 1;
+  border-radius: 4px;
+  opacity: 0;
+  transition: opacity 0.24s ease-out;
+}
+.mx-scrollbar-track .mx-scrollbar-thumb {
+  position: absolute;
+  width: 100%;
+  height: 0;
+  cursor: pointer;
+  border-radius: inherit;
+  background-color: rgba(144, 147, 153, 0.3);
+  transition: background-color 0.3s;
+}
+.mx-zoom-in-down-enter-active,
+.mx-zoom-in-down-leave-active {
+  opacity: 1;
+  transform: scaleY(1);
+  transition: transform 0.3s cubic-bezier(0.23, 1, 0.32, 1), opacity 0.3s cubic-bezier(0.23, 1, 0.32, 1);
+  transform-origin: center top;
+}
+.mx-zoom-in-down-enter,
+.mx-zoom-in-down-enter-from,
+.mx-zoom-in-down-leave-to {
+  opacity: 0;
+  transform: scaleY(0);
+}
+.mx-datepicker {
+  position: relative;
+  display: inline-block;
+  width: 210px;
+}
+.mx-datepicker svg {
+  width: 1em;
+  height: 1em;
+  vertical-align: -0.15em;
+  fill: currentColor;
+  overflow: hidden;
+}
+.mx-datepicker-range {
+  width: 320px;
+}
+.mx-datepicker-inline {
+  width: auto;
+}
+.mx-input-wrapper {
+  position: relative;
+}
+.mx-input {
+  display: inline-block;
+  box-sizing: border-box;
+  width: 100%;
+  height: 34px;
+  padding: 6px 30px;
+  padding-left: 10px;
+  font-size: 14px;
+  line-height: 1.4;
+  color: #555;
+  background-color: #fff;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
+}
+.mx-input:hover, .mx-input:focus {
+  border-color: #409aff;
+}
+.mx-input:disabled, .mx-input.disabled {
+  color: #ccc;
+  background-color: #f3f3f3;
+  border-color: #ccc;
+  cursor: not-allowed;
+}
+.mx-input:focus {
+  outline: none;
+}
+.mx-input::-ms-clear {
+  display: none;
+}
+.mx-icon-calendar,
+.mx-icon-clear {
+  position: absolute;
+  top: 50%;
+  right: 8px;
+  transform: translateY(-50%);
+  font-size: 16px;
+  line-height: 1;
+  color: rgba(0, 0, 0, 0.5);
+  vertical-align: middle;
+}
+.mx-icon-clear {
+  cursor: pointer;
+}
+.mx-icon-clear:hover {
+  color: rgba(0, 0, 0, 0.8);
+}
+.mx-datepicker-main {
+  font: 14px/1.5 "Helvetica Neue", Helvetica, Arial, "Microsoft Yahei", sans-serif;
+  color: #73879c;
+  background-color: #fff;
+  border: 1px solid #e8e8e8;
+}
+.mx-datepicker-popup {
+  position: absolute;
+  margin-top: 1px;
+  margin-bottom: 1px;
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+  z-index: 2001;
+}
+.mx-datepicker-sidebar {
+  float: left;
+  box-sizing: border-box;
+  width: 100px;
+  padding: 6px;
+  overflow: auto;
+}
+.mx-datepicker-sidebar + .mx-datepicker-content {
+  margin-left: 100px;
+  border-left: 1px solid #e8e8e8;
+}
+.mx-datepicker-body {
+  position: relative;
+  user-select: none;
+}
+.mx-btn-shortcut {
+  display: block;
+  padding: 0 6px;
+  line-height: 24px;
+}
+.mx-range-wrapper {
+  display: flex;
+}
+@media (max-width: 750px) {
+  .mx-range-wrapper {
+    flex-direction: column;
+  }
+}
+.mx-datepicker-header {
+  padding: 6px 8px;
+  border-bottom: 1px solid #e8e8e8;
+}
+.mx-datepicker-footer {
+  padding: 6px 8px;
+  text-align: right;
+  border-top: 1px solid #e8e8e8;
+}
+.mx-calendar {
+  box-sizing: border-box;
+  width: 248px;
+  padding: 6px 12px;
+}
+.mx-calendar + .mx-calendar {
+  border-left: 1px solid #e8e8e8;
+}
+.mx-calendar-header, .mx-time-header {
+  box-sizing: border-box;
+  height: 34px;
+  line-height: 34px;
+  text-align: center;
+  overflow: hidden;
+}
+.mx-btn-icon-left,
+.mx-btn-icon-double-left {
+  float: left;
+}
+.mx-btn-icon-right,
+.mx-btn-icon-double-right {
+  float: right;
+}
+.mx-calendar-header-label {
+  font-size: 14px;
+}
+.mx-calendar-decade-separator {
+  margin: 0 2px;
+}
+.mx-calendar-decade-separator:after {
+  content: "~";
+}
+.mx-calendar-content {
+  position: relative;
+  height: 224px;
+  box-sizing: border-box;
+}
+.mx-calendar-content .cell {
+  cursor: pointer;
+}
+.mx-calendar-content .cell:hover {
+  color: #73879c;
+  background-color: #f3f9fe;
+}
+.mx-calendar-content .cell.active {
+  color: #fff;
+  background-color: #1284e7;
+}
+.mx-calendar-content .cell.in-range, .mx-calendar-content .cell.hover-in-range {
+  color: #73879c;
+  background-color: #dbedfb;
+}
+.mx-calendar-content .cell.disabled {
+  cursor: not-allowed;
+  color: #ccc;
+  background-color: #f3f3f3;
+}
+.mx-calendar-week-mode .mx-date-row {
+  cursor: pointer;
+}
+.mx-calendar-week-mode .mx-date-row:hover {
+  background-color: #f3f9fe;
+}
+.mx-calendar-week-mode .mx-date-row.mx-active-week {
+  background-color: #dbedfb;
+}
+.mx-calendar-week-mode .mx-date-row .cell:hover {
+  color: inherit;
+  background-color: transparent;
+}
+.mx-calendar-week-mode .mx-date-row .cell.active {
+  color: inherit;
+  background-color: transparent;
+}
+.mx-week-number {
+  opacity: 0.5;
+}
+.mx-table {
+  table-layout: fixed;
+  border-collapse: separate;
+  border-spacing: 0;
+  width: 100%;
+  height: 100%;
+  box-sizing: border-box;
+  text-align: center;
+}
+.mx-table th {
+  padding: 0;
+  font-weight: 500;
+  vertical-align: middle;
+}
+.mx-table td {
+  padding: 0;
+  vertical-align: middle;
+}
+.mx-table-date td,
+.mx-table-date th {
+  height: 32px;
+  font-size: 12px;
+}
+.mx-table-date .today {
+  color: #2a90e9;
+}
+.mx-table-date .cell.not-current-month {
+  color: #ccc;
+  background: none;
+}
+.mx-time {
+  flex: 1;
+  width: 224px;
+  background: #fff;
+}
+.mx-time + .mx-time {
+  border-left: 1px solid #e8e8e8;
+}
+.mx-calendar-time {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+.mx-time-header {
+  border-bottom: 1px solid #e8e8e8;
+}
+.mx-time-content {
+  height: 224px;
+  box-sizing: border-box;
+  overflow: hidden;
+}
+.mx-time-columns {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+.mx-time-column {
+  flex: 1;
+  position: relative;
+  border-left: 1px solid #e8e8e8;
+  text-align: center;
+}
+.mx-time-column:first-child {
+  border-left: 0;
+}
+.mx-time-column .mx-time-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.mx-time-column .mx-time-list::after {
+  content: "";
+  display: block;
+  height: 192px;
+}
+.mx-time-column .mx-time-item {
+  cursor: pointer;
+  font-size: 12px;
+  height: 32px;
+  line-height: 32px;
+}
+.mx-time-column .mx-time-item:hover {
+  color: #73879c;
+  background-color: #f3f9fe;
+}
+.mx-time-column .mx-time-item.active {
+  color: #1284e7;
+  background-color: transparent;
+  font-weight: 700;
+}
+.mx-time-column .mx-time-item.disabled {
+  cursor: not-allowed;
+  color: #ccc;
+  background-color: #f3f3f3;
+}
+.mx-time-option {
+  cursor: pointer;
+  padding: 8px 10px;
+  font-size: 14px;
+  line-height: 20px;
+}
+.mx-time-option:hover {
+  color: #73879c;
+  background-color: #f3f9fe;
+}
+.mx-time-option.active {
+  color: #1284e7;
+  background-color: transparent;
+  font-weight: 700;
+}
+.mx-time-option.disabled {
+  cursor: not-allowed;
+  color: #ccc;
+  background-color: #f3f3f3;
+}
+.mx-datepicker[data-v-9457a3d] {
+  user-select: none;
+  color: var(--color-main-text);
+  /* INPUT CONTAINER */
+}
+.mx-datepicker[data-v-9457a3d] svg {
+  fill: var(--color-main-text);
+}
+.mx-datepicker[data-v-9457a3d] .mx-input-wrapper .mx-input {
+  width: 100%;
+  border: 2px solid var(--color-border-maxcontrast);
+  background-color: var(--color-main-background);
+  background-clip: content-box;
+}
+.mx-datepicker[data-v-9457a3d] .mx-input-wrapper .mx-input:active:not(.disabled), .mx-datepicker[data-v-9457a3d] .mx-input-wrapper .mx-input:hover:not(.disabled), .mx-datepicker[data-v-9457a3d] .mx-input-wrapper .mx-input:focus:not(.disabled) {
+  border-color: var(--color-primary-element);
+}
+.mx-datepicker[data-v-9457a3d] .mx-input-wrapper:disabled, .mx-datepicker[data-v-9457a3d] .mx-input-wrapper.disabled {
+  cursor: not-allowed;
+  opacity: 0.7;
+}
+.mx-datepicker[data-v-9457a3d] .mx-input-wrapper .mx-icon-calendar,
+.mx-datepicker[data-v-9457a3d] .mx-input-wrapper .mx-icon-clear {
+  color: var(--color-text-lighter);
+}
+.mx-datepicker-main {
+  color: var(--color-main-text);
+  border: 1px solid var(--color-border);
+  background-color: var(--color-main-background);
+  font-family: var(--font-face) !important;
+  line-height: 1.5;
+}
+.mx-datepicker-main svg {
+  fill: var(--color-main-text);
+}
+.mx-datepicker-main.mx-datepicker-popup {
+  z-index: 2000;
+  box-shadow: none;
+}
+.mx-datepicker-main.mx-datepicker-popup .mx-datepicker-sidebar + .mx-datepicker-content {
+  border-left: 1px solid var(--color-border);
+}
+.mx-datepicker-main.show-week-number .mx-calendar {
+  width: 296px;
+}
+.mx-datepicker-main .mx-datepicker-header {
+  border-bottom: 1px solid var(--color-border);
+}
+.mx-datepicker-main .mx-datepicker-footer {
+  border-top: 1px solid var(--color-border);
+}
+.mx-datepicker-main .mx-datepicker-btn-confirm {
+  background-color: var(--color-primary-element);
+  border-color: var(--color-primary-element);
+  color: var(--color-primary-element-text) !important;
+  opacity: 1 !important;
+}
+.mx-datepicker-main .mx-datepicker-btn-confirm:hover {
+  background-color: var(--color-primary-element-light) !important;
+  border-color: var(--color-primary-element-light) !important;
+}
+.mx-datepicker-main .mx-calendar {
+  width: 264px;
+  padding: 5px;
+}
+.mx-datepicker-main .mx-calendar.mx-calendar-week-mode {
+  width: 296px;
+}
+.mx-datepicker-main .mx-time + .mx-time,
+.mx-datepicker-main .mx-calendar + .mx-calendar {
+  border-left: 1px solid var(--color-border);
+}
+.mx-datepicker-main .mx-range-wrapper {
+  display: flex;
+  overflow: hidden;
+}
+.mx-datepicker-main .mx-range-wrapper .mx-calendar-content .mx-table-date .cell.active {
+  border-radius: var(--border-radius) 0 0 var(--border-radius);
+}
+.mx-datepicker-main .mx-range-wrapper .mx-calendar-content .mx-table-date .cell.in-range + .cell.active {
+  border-radius: 0 var(--border-radius) var(--border-radius) 0;
+}
+.mx-datepicker-main .mx-table {
+  text-align: center;
+}
+.mx-datepicker-main .mx-table thead > tr > th {
+  text-align: center;
+  opacity: 0.5;
+  color: var(--color-text-lighter);
+}
+.mx-datepicker-main .mx-table tr:focus,
+.mx-datepicker-main .mx-table tr:hover,
+.mx-datepicker-main .mx-table tr:active {
+  background-color: transparent;
+}
+.mx-datepicker-main .mx-table .cell {
+  transition: all 100ms ease-in-out;
+  text-align: center;
+  opacity: 0.7;
+  border-radius: 50px;
+}
+.mx-datepicker-main .mx-table .cell > * {
+  cursor: pointer;
+}
+.mx-datepicker-main .mx-table .cell.today {
+  opacity: 1;
+  color: var(--color-primary-element);
+  font-weight: bold;
+}
+.mx-datepicker-main .mx-table .cell.today:hover, .mx-datepicker-main .mx-table .cell.today:focus {
+  color: var(--color-primary-element-text);
+}
+.mx-datepicker-main .mx-table .cell.in-range, .mx-datepicker-main .mx-table .cell.disabled {
+  border-radius: 0;
+  font-weight: normal;
+}
+.mx-datepicker-main .mx-table .cell.in-range {
+  opacity: 0.7;
+}
+.mx-datepicker-main .mx-table .cell.not-current-month {
+  opacity: 0.5;
+  color: var(--color-text-lighter);
+}
+.mx-datepicker-main .mx-table .cell.not-current-month:hover, .mx-datepicker-main .mx-table .cell.not-current-month:focus {
+  opacity: 1;
+}
+.mx-datepicker-main .mx-table .cell:hover, .mx-datepicker-main .mx-table .cell:focus, .mx-datepicker-main .mx-table .cell.actived, .mx-datepicker-main .mx-table .cell.active, .mx-datepicker-main .mx-table .cell.in-range {
+  opacity: 1;
+  color: var(--color-primary-element-text);
+  background-color: var(--color-primary-element);
+  font-weight: bold;
+}
+.mx-datepicker-main .mx-table .cell.disabled {
+  opacity: 0.5;
+  color: var(--color-text-lighter);
+  border-radius: 0;
+  background-color: var(--color-background-darker);
+}
+.mx-datepicker-main .mx-table .mx-week-number {
+  text-align: center;
+  opacity: 0.7;
+  border-radius: 50px;
+}
+.mx-datepicker-main .mx-table span.mx-week-number,
+.mx-datepicker-main .mx-table li.mx-week-number,
+.mx-datepicker-main .mx-table span.cell,
+.mx-datepicker-main .mx-table li.cell {
+  min-height: 32px;
+}
+.mx-datepicker-main .mx-table.mx-table-date thead, .mx-datepicker-main .mx-table.mx-table-date tbody, .mx-datepicker-main .mx-table.mx-table-year, .mx-datepicker-main .mx-table.mx-table-month {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-around;
+}
+.mx-datepicker-main .mx-table.mx-table-date thead tr, .mx-datepicker-main .mx-table.mx-table-date tbody tr, .mx-datepicker-main .mx-table.mx-table-year tr, .mx-datepicker-main .mx-table.mx-table-month tr {
+  display: inline-flex;
+  align-items: center;
+  flex: 1 1 32px;
+  justify-content: space-around;
+  min-height: 32px;
+}
+.mx-datepicker-main .mx-table.mx-table-date thead th,
+.mx-datepicker-main .mx-table.mx-table-date thead td, .mx-datepicker-main .mx-table.mx-table-date tbody th,
+.mx-datepicker-main .mx-table.mx-table-date tbody td, .mx-datepicker-main .mx-table.mx-table-year th,
+.mx-datepicker-main .mx-table.mx-table-year td, .mx-datepicker-main .mx-table.mx-table-month th,
+.mx-datepicker-main .mx-table.mx-table-month td {
+  display: flex;
+  align-items: center;
+  flex: 0 1 32%;
+  justify-content: center;
+  min-width: 32px;
+  height: 95%;
+  min-height: 32px;
+  transition: background 100ms ease-in-out;
+}
+.mx-datepicker-main .mx-table.mx-table-year tr th,
+.mx-datepicker-main .mx-table.mx-table-year tr td {
+  flex-basis: 48%;
+}
+.mx-datepicker-main .mx-table.mx-table-date tr th,
+.mx-datepicker-main .mx-table.mx-table-date tr td {
+  flex-basis: 32px;
+}
+.mx-datepicker-main .mx-btn {
+  min-width: 32px;
+  height: 32px;
+  margin: 0 2px !important;
+  padding: 7px 10px;
+  cursor: pointer;
+  text-decoration: none;
+  opacity: 0.5;
+  color: var(--color-text-lighter);
+  border-radius: 32px;
+  line-height: 20px;
+}
+.mx-datepicker-main .mx-btn:hover, .mx-datepicker-main .mx-btn:focus {
+  opacity: 1;
+  color: var(--color-main-text);
+  background-color: var(--color-background-darker);
+}
+.mx-datepicker-main .mx-calendar-header, .mx-datepicker-main .mx-time-header {
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  height: var(--default-clickable-area);
+  margin-bottom: 4px;
+}
+.mx-datepicker-main .mx-calendar-header button, .mx-datepicker-main .mx-time-header button {
+  min-width: 32px;
+  min-height: 32px;
+  margin: 0;
+  cursor: pointer;
+  text-align: center;
+  text-decoration: none;
+  opacity: 0.7;
+  color: var(--color-main-text);
+  border-radius: 32px;
+  line-height: 20px;
+}
+.mx-datepicker-main .mx-calendar-header button:hover, .mx-datepicker-main .mx-time-header button:hover, .mx-datepicker-main .mx-calendar-header button:focus, .mx-datepicker-main .mx-time-header button:focus {
+  opacity: 1;
+  color: var(--color-main-text);
+  background-color: var(--color-background-darker);
+}
+.mx-datepicker-main .mx-calendar-header button.mx-btn-icon-double-left, .mx-datepicker-main .mx-time-header button.mx-btn-icon-double-left, .mx-datepicker-main .mx-calendar-header button.mx-btn-icon-left, .mx-datepicker-main .mx-time-header button.mx-btn-icon-left, .mx-datepicker-main .mx-calendar-header button.mx-btn-icon-right, .mx-datepicker-main .mx-time-header button.mx-btn-icon-right, .mx-datepicker-main .mx-calendar-header button.mx-btn-icon-double-right, .mx-datepicker-main .mx-time-header button.mx-btn-icon-double-right {
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  padding: 0;
+}
+.mx-datepicker-main .mx-calendar-header button.mx-btn-icon-double-left > i, .mx-datepicker-main .mx-time-header button.mx-btn-icon-double-left > i, .mx-datepicker-main .mx-calendar-header button.mx-btn-icon-left > i, .mx-datepicker-main .mx-time-header button.mx-btn-icon-left > i, .mx-datepicker-main .mx-calendar-header button.mx-btn-icon-right > i, .mx-datepicker-main .mx-time-header button.mx-btn-icon-right > i, .mx-datepicker-main .mx-calendar-header button.mx-btn-icon-double-right > i, .mx-datepicker-main .mx-time-header button.mx-btn-icon-double-right > i {
+  background-repeat: no-repeat;
+  background-size: 16px;
+  background-position: center;
+  filter: var(--background-invert-if-dark);
+  display: inline-block;
+  width: 32px;
+  height: 32px;
+}
+.mx-datepicker-main .mx-calendar-header button.mx-btn-icon-double-left > i::after, .mx-datepicker-main .mx-time-header button.mx-btn-icon-double-left > i::after, .mx-datepicker-main .mx-calendar-header button.mx-btn-icon-double-left > i::before, .mx-datepicker-main .mx-time-header button.mx-btn-icon-double-left > i::before, .mx-datepicker-main .mx-calendar-header button.mx-btn-icon-left > i::after, .mx-datepicker-main .mx-time-header button.mx-btn-icon-left > i::after, .mx-datepicker-main .mx-calendar-header button.mx-btn-icon-left > i::before, .mx-datepicker-main .mx-time-header button.mx-btn-icon-left > i::before, .mx-datepicker-main .mx-calendar-header button.mx-btn-icon-right > i::after, .mx-datepicker-main .mx-time-header button.mx-btn-icon-right > i::after, .mx-datepicker-main .mx-calendar-header button.mx-btn-icon-right > i::before, .mx-datepicker-main .mx-time-header button.mx-btn-icon-right > i::before, .mx-datepicker-main .mx-calendar-header button.mx-btn-icon-double-right > i::after, .mx-datepicker-main .mx-time-header button.mx-btn-icon-double-right > i::after, .mx-datepicker-main .mx-calendar-header button.mx-btn-icon-double-right > i::before, .mx-datepicker-main .mx-time-header button.mx-btn-icon-double-right > i::before {
+  content: none;
+}
+.mx-datepicker-main .mx-calendar-header button.mx-btn-text, .mx-datepicker-main .mx-time-header button.mx-btn-text {
+  line-height: initial;
+}
+.mx-datepicker-main .mx-calendar-header .mx-calendar-header-label, .mx-datepicker-main .mx-time-header .mx-calendar-header-label {
+  display: flex;
+}
+.mx-datepicker-main .mx-calendar-header .mx-btn-icon-double-left > i, .mx-datepicker-main .mx-time-header .mx-btn-icon-double-left > i {
+  background-image: url("data:image/svg+xml,%3c!--%20-%20SPDX-FileCopyrightText:%202020%20Google%20Inc.%20-%20SPDX-License-Identifier:%20Apache-2.0%20--%3e%3csvg%20xmlns='http://www.w3.org/2000/svg'%20width='24'%20height='24'%20fill='%23222'%3e%3cpath%20d='M18.4%207.4L17%206l-6%206%206%206%201.4-1.4-4.6-4.6%204.6-4.6m-6%200L11%206l-6%206%206%206%201.4-1.4L7.8%2012l4.6-4.6z'/%3e%3c/svg%3e");
+}
+.mx-datepicker-main .mx-calendar-header .mx-btn-icon-left > i, .mx-datepicker-main .mx-time-header .mx-btn-icon-left > i {
+  background-image: url("data:image/svg+xml,%3c!--%20-%20SPDX-FileCopyrightText:%202020%20Google%20Inc.%20-%20SPDX-License-Identifier:%20Apache-2.0%20--%3e%3csvg%20xmlns='http://www.w3.org/2000/svg'%20width='24'%20height='24'%20fill='%23222'%3e%3cpath%20d='M15.4%2016.6L10.8%2012l4.6-4.6L14%206l-6%206%206%206%201.4-1.4z'/%3e%3c/svg%3e");
+}
+.mx-datepicker-main .mx-calendar-header .mx-btn-icon-right > i, .mx-datepicker-main .mx-time-header .mx-btn-icon-right > i {
+  background-image: url("data:image/svg+xml,%3c!--%20-%20SPDX-FileCopyrightText:%202020%20Google%20Inc.%20-%20SPDX-License-Identifier:%20Apache-2.0%20--%3e%3csvg%20xmlns='http://www.w3.org/2000/svg'%20width='24'%20height='24'%20fill='%23222'%3e%3cpath%20d='M8.6%2016.6l4.6-4.6-4.6-4.6L10%206l6%206-6%206-1.4-1.4z'/%3e%3c/svg%3e");
+}
+.mx-datepicker-main .mx-calendar-header .mx-btn-icon-double-right > i, .mx-datepicker-main .mx-time-header .mx-btn-icon-double-right > i {
+  background-image: url("data:image/svg+xml,%3c!--%20-%20SPDX-FileCopyrightText:%202020%20Google%20Inc.%20-%20SPDX-License-Identifier:%20Apache-2.0%20--%3e%3csvg%20xmlns='http://www.w3.org/2000/svg'%20width='24'%20height='24'%20fill='%23222'%3e%3cpath%20d='M5.6%207.4L7%206l6%206-6%206-1.4-1.4%204.6-4.6-4.6-4.6m6%200L13%206l6%206-6%206-1.4-1.4%204.6-4.6-4.6-4.6z'/%3e%3c/svg%3e");
+}
+.mx-datepicker-main .mx-calendar-header button.mx-btn-icon-right, .mx-datepicker-main .mx-time-header button.mx-btn-icon-right {
+  order: 2;
+}
+.mx-datepicker-main .mx-calendar-header button.mx-btn-icon-double-right, .mx-datepicker-main .mx-time-header button.mx-btn-icon-double-right {
+  order: 3;
+}
+.mx-datepicker-main .mx-calendar-week-mode .mx-date-row .mx-week-number {
+  font-weight: bold;
+}
+.mx-datepicker-main .mx-calendar-week-mode .mx-date-row:hover, .mx-datepicker-main .mx-calendar-week-mode .mx-date-row.mx-active-week {
+  opacity: 1;
+  border-radius: 50px;
+  background-color: var(--color-background-dark);
+}
+.mx-datepicker-main .mx-calendar-week-mode .mx-date-row:hover td, .mx-datepicker-main .mx-calendar-week-mode .mx-date-row.mx-active-week td {
+  background-color: transparent;
+}
+.mx-datepicker-main .mx-calendar-week-mode .mx-date-row:hover td, .mx-datepicker-main .mx-calendar-week-mode .mx-date-row:hover td:hover, .mx-datepicker-main .mx-calendar-week-mode .mx-date-row:hover td:focus, .mx-datepicker-main .mx-calendar-week-mode .mx-date-row.mx-active-week td, .mx-datepicker-main .mx-calendar-week-mode .mx-date-row.mx-active-week td:hover, .mx-datepicker-main .mx-calendar-week-mode .mx-date-row.mx-active-week td:focus {
+  color: inherit;
+}
+.mx-datepicker-main .mx-calendar-week-mode .mx-date-row.mx-active-week {
+  color: var(--color-primary-element-text);
+  background-color: var(--color-primary-element);
+}
+.mx-datepicker-main .mx-calendar-week-mode .mx-date-row.mx-active-week td {
+  opacity: 0.7;
+  font-weight: normal;
+}
+.mx-datepicker-main .mx-time {
+  background-color: var(--color-main-background);
+}
+.mx-datepicker-main .mx-time .mx-time-header {
+  justify-content: center;
+  border-bottom: 1px solid var(--color-border);
+}
+.mx-datepicker-main .mx-time .mx-time-column {
+  border-left: 1px solid var(--color-border);
+}
+.mx-datepicker-main .mx-time .mx-time-option.active, .mx-datepicker-main .mx-time .mx-time-option:hover,
+.mx-datepicker-main .mx-time .mx-time-item.active,
+.mx-datepicker-main .mx-time .mx-time-item:hover {
+  color: var(--color-primary-element-text);
+  background-color: var(--color-primary-element);
+}
+.mx-datepicker-main .mx-time .mx-time-option.disabled,
+.mx-datepicker-main .mx-time .mx-time-item.disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+  color: var(--color-main-text);
+  background-color: var(--color-main-background);
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-4727c294] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.mx-datepicker[data-v-4727c294] .mx-input-wrapper .mx-input {
+  background-clip: border-box;
+}
+.datetime-picker-inline-icon[data-v-4727c294] {
+  opacity: 0.3;
+  border: none;
+  background-color: transparent;
+  border-radius: 0;
+  padding: 0 !important;
+  margin: 0;
+}
+.datetime-picker-inline-icon--highlighted[data-v-4727c294] {
+  opacity: 0.7;
+}
+.datetime-picker-inline-icon[data-v-4727c294]:focus, .datetime-picker-inline-icon[data-v-4727c294]:hover {
+  opacity: 1;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.v-popper--theme-dropdown.v-popper__popper.timezone-select__popper .v-popper__wrapper {
+  border-radius: var(--border-radius-large);
+}
+.v-popper--theme-dropdown.v-popper__popper.timezone-select__popper .v-popper__wrapper .v-popper__inner {
+  padding: 4px;
+  border-radius: var(--border-radius-large);
+}
+.v-popper--theme-dropdown.v-popper__popper.timezone-select__popper .v-popper__wrapper .v-popper__inner .timezone-popover-wrapper__label {
+  padding: 4px 0;
+  padding-left: 14px;
+}
+.v-popper--theme-dropdown.v-popper__popper.timezone-select__popper .v-popper__wrapper .v-popper__inner .timezone-popover-wrapper__timezone-select.v-select .vs__dropdown-toggle {
+  border-radius: calc(var(--border-radius-large) - 4px);
+}
+.v-popper--theme-dropdown.v-popper__popper.timezone-select__popper .v-popper__wrapper .v-popper__inner .timezone-popover-wrapper__timezone-select.v-select.vs--open .vs__dropdown-toggle {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+.v-popper--theme-dropdown.v-popper__popper.timezone-select__popper .v-popper__wrapper .v-popper__inner .timezone-popover-wrapper__timezone-select.v-select.vs--open.select--drop-up .vs__dropdown-toggle {
+  border-radius: 0 0 calc(var(--border-radius-large) - 4px) calc(var(--border-radius-large) - 4px);
+}
+.vs__dropdown-menu--floating {
+  z-index: 100001 !important;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+body {
+  /**
+   * Set custom vue-select CSS variables.
+   * Needs to be on the body (not :root) for theming to apply (see nextcloud/server#36462)
+   */
+  /* Search Input */
+  --vs-search-input-color: var(--color-main-text);
+  --vs-search-input-bg: var(--color-main-background);
+  --vs-search-input-placeholder-color: var(--color-text-maxcontrast);
+  /* Font */
+  --vs-font-size: var(--default-font-size);
+  --vs-line-height: var(--default-line-height);
+  /* Disabled State */
+  --vs-state-disabled-bg: var(--color-background-hover);
+  --vs-state-disabled-color: var(--color-text-maxcontrast);
+  --vs-state-disabled-controls-color: var(--color-text-maxcontrast);
+  --vs-state-disabled-cursor: not-allowed;
+  --vs-disabled-bg: var(--color-background-hover);
+  --vs-disabled-color: var(--color-text-maxcontrast);
+  --vs-disabled-cursor: not-allowed;
+  /* Borders */
+  --vs-border-color: var(--color-border-maxcontrast);
+  --vs-border-width: var(--border-width-input, 2px) !important;
+  --vs-border-style: solid;
+  --vs-border-radius: var(--border-radius-large);
+  /* Component Controls: Clear, Open Indicator */
+  --vs-controls-color: var(--color-main-text);
+  /* Selected */
+  --vs-selected-bg: var(--color-background-hover);
+  --vs-selected-color: var(--color-main-text);
+  --vs-selected-border-color: var(--vs-border-color);
+  --vs-selected-border-style: var(--vs-border-style);
+  --vs-selected-border-width: var(--vs-border-width);
+  /* Dropdown */
+  --vs-dropdown-bg: var(--color-main-background);
+  --vs-dropdown-color: var(--color-main-text);
+  --vs-dropdown-z-index: 9999;
+  --vs-dropdown-box-shadow: 0px 2px 2px 0px var(--color-box-shadow);
+  /* Options */
+  --vs-dropdown-option-padding: 8px 20px;
+  /* Active State */
+  --vs-dropdown-option--active-bg: var(--color-background-hover);
+  --vs-dropdown-option--active-color: var(--color-main-text);
+  /* Keyboard Focus State */
+  --vs-dropdown-option--kb-focus-box-shadow: inset 0px 0px 0px 2px var(--vs-border-color);
+  /* Deselect State */
+  --vs-dropdown-option--deselect-bg: var(--color-error);
+  --vs-dropdown-option--deselect-color: #fff;
+  /* Transitions */
+  --vs-transition-duration: 0ms;
+  /* Actions */
+  --vs-actions-padding: 0 8px 0 4px;
+}
+.v-select.select {
+  /* Override default vue-select styles */
+  min-height: var(--default-clickable-area);
+  min-width: 260px;
+  margin: 0 0 var(--default-grid-baseline);
+}
+.v-select.select.vs--open {
+  --vs-border-width: var(--border-width-input-focused, 2px);
+}
+.v-select.select .select__label {
+  display: block;
+  margin-bottom: 2px;
+}
+.v-select.select .vs__selected {
+  height: calc(var(--default-clickable-area) - 2 * var(--vs-border-width) - var(--default-grid-baseline));
+  margin: calc(var(--default-grid-baseline) / 2);
+  padding-block: 0;
+  padding-inline: 12px 8px;
+  border-radius: 16px !important;
+  background: var(--color-primary-element-light);
+  border: none;
+}
+.v-select.select.vs--open .vs__selected:first-of-type {
+  margin-inline-start: calc(var(--default-grid-baseline) / 2 - (var(--border-width-input-focused, 2px) - var(--border-width-input, 2px))) !important;
+}
+.v-select.select .vs__search {
+  text-overflow: ellipsis;
+  color: var(--color-main-text);
+  min-height: unset !important;
+  height: calc(var(--default-clickable-area) - 2 * var(--vs-border-width)) !important;
+}
+.v-select.select .vs__search::placeholder {
+  color: var(--color-text-maxcontrast);
+}
+.v-select.select .vs__search, .v-select.select .vs__search:focus {
+  margin: 0;
+}
+.v-select.select .vs__dropdown-toggle {
+  position: relative;
+  max-height: 100px;
+  padding: 0;
+  overflow-y: auto;
+}
+.v-select.select .vs__actions {
+  position: sticky;
+  top: 0;
+}
+.v-select.select .vs__clear {
+  margin-right: 2px;
+}
+.v-select.select.vs--open .vs__dropdown-toggle {
+  border-width: var(--border-width-input-focused);
+  outline: 2px solid var(--color-main-background);
+  border-color: var(--color-main-text);
+  border-bottom-color: transparent;
+}
+.v-select.select:not(.vs--disabled, .vs--open) .vs__dropdown-toggle:hover {
+  outline: 2px solid var(--color-main-background);
+  border-color: var(--color-main-text);
+}
+.v-select.select.vs--disabled .vs__search,
+.v-select.select.vs--disabled .vs__selected {
+  color: var(--color-text-maxcontrast);
+}
+.v-select.select.vs--disabled .vs__clear,
+.v-select.select.vs--disabled .vs__deselect {
+  display: none;
+}
+.v-select.select--no-wrap .vs__selected-options {
+  flex-wrap: nowrap;
+  overflow: auto;
+  min-width: unset;
+}
+.v-select.select--no-wrap .vs__selected-options .vs__selected {
+  min-width: unset;
+}
+.v-select.select--drop-up.vs--open .vs__dropdown-toggle {
+  border-radius: 0 0 var(--vs-border-radius) var(--vs-border-radius);
+  border-top-color: transparent;
+  border-bottom-color: var(--color-main-text);
+}
+.v-select.select .vs__selected-options {
+  min-height: calc(var(--default-clickable-area) - 2 * var(--vs-border-width));
+  padding: 0 5px;
+}
+.v-select.select .vs__selected-options .vs__selected ~ .vs__search[readonly] {
+  position: absolute;
+}
+.v-select.select.vs--single.vs--loading .vs__selected, .v-select.select.vs--single.vs--open .vs__selected {
+  max-width: 100%;
+  opacity: 1;
+  color: var(--color-text-maxcontrast);
+}
+.v-select.select.vs--single .vs__selected-options {
+  flex-wrap: nowrap;
+}
+.v-select.select.vs--single .vs__selected {
+  background: unset !important;
+}
+.vs__dropdown-menu {
+  border-width: var(--border-width-input-focused) !important;
+  border-color: var(--color-main-text) !important;
+  outline: none !important;
+  box-shadow: -2px 0 0 var(--color-main-background), 0 2px 0 var(--color-main-background), 2px 0 0 var(--color-main-background), !important;
+  padding: 4px !important;
+}
+.vs__dropdown-menu--floating {
+  /* Fallback styles overidden by programmatically set inline styles */
+  width: max-content;
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+.vs__dropdown-menu--floating-placement-top {
+  border-radius: var(--vs-border-radius) var(--vs-border-radius) 0 0 !important;
+  border-top-style: var(--vs-border-style) !important;
+  border-bottom-style: none !important;
+  box-shadow: 0 -2px 0 var(--color-main-background), -2px 0 0 var(--color-main-background), 2px 0 0 var(--color-main-background), !important;
+}
+.vs__dropdown-menu .vs__dropdown-option {
+  border-radius: 6px !important;
+}
+.vs__dropdown-menu .vs__no-options {
+  color: var(--color-text-lighter) !important;
+}
+.user-select .vs__selected {
+  padding-inline: 0 5px !important;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-0c4478a6] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.name-parts[data-v-0c4478a6] {
+  display: flex;
+  max-width: 100%;
+  cursor: inherit;
+}
+.name-parts__first[data-v-0c4478a6] {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.name-parts__first[data-v-0c4478a6], .name-parts__last[data-v-0c4478a6] {
+  white-space: pre;
+  cursor: inherit;
+}
+.name-parts__first strong[data-v-0c4478a6], .name-parts__last strong[data-v-0c4478a6] {
+  font-weight: bold;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-a519576f] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.mention-bubble--primary .mention-bubble__content[data-v-a519576f] {
+  color: var(--color-primary-element-text);
+  background-color: var(--color-primary-element);
+}
+.mention-bubble__wrapper[data-v-a519576f] {
+  max-width: 150px;
+  height: 18px;
+  vertical-align: text-bottom;
+  display: inline-flex;
+  align-items: center;
+}
+.mention-bubble__content[data-v-a519576f] {
+  display: inline-flex;
+  overflow: hidden;
+  align-items: center;
+  max-width: 100%;
+  height: 20px;
+  -webkit-user-select: none;
+  user-select: none;
+  padding-right: 6px;
+  padding-left: 2px;
+  border-radius: 10px;
+  background-color: var(--color-background-dark);
+}
+.mention-bubble__icon[data-v-a519576f] {
+  position: relative;
+  width: 16px;
+  height: 16px;
+  border-radius: 8px;
+  background-color: var(--color-background-darker);
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 12px;
+}
+.mention-bubble__icon--with-avatar[data-v-a519576f] {
+  color: inherit;
+  background-size: cover;
+}
+.mention-bubble__title[data-v-a519576f] {
+  overflow: hidden;
+  margin-left: 2px;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+.mention-bubble__title[data-v-a519576f]::before {
+  content: attr(title);
+}
+.mention-bubble__select[data-v-a519576f] {
+  position: absolute;
+  z-index: -1;
+  left: -100vw;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-a0f4d73a] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.option[data-v-a0f4d73a] {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: var(--height);
+  cursor: inherit;
+}
+.option__avatar[data-v-a0f4d73a] {
+  margin-right: var(--margin);
+}
+.option__details[data-v-a0f4d73a] {
+  display: flex;
+  flex: 1 1;
+  flex-direction: column;
+  justify-content: center;
+  min-width: 0;
+}
+.option__lineone[data-v-a0f4d73a] {
+  color: var(--color-main-text);
+}
+.option__linetwo[data-v-a0f4d73a] {
+  color: var(--color-text-maxcontrast);
+}
+.option__lineone[data-v-a0f4d73a], .option__linetwo[data-v-a0f4d73a] {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  line-height: 1.2;
+}
+.option__lineone strong[data-v-a0f4d73a], .option__linetwo strong[data-v-a0f4d73a] {
+  font-weight: bold;
+}
+.option--compact .option__lineone[data-v-a0f4d73a] {
+  font-size: 14px;
+}
+.option--compact .option__linetwo[data-v-a0f4d73a] {
+  font-size: 11px;
+  line-height: 1.5;
+  margin-top: -4px;
+}
+.option__icon[data-v-a0f4d73a] {
+  width: var(--default-clickable-area);
+  height: var(--default-clickable-area);
+  color: var(--color-text-maxcontrast);
+}
+.option__icon.icon[data-v-a0f4d73a] {
+  flex: 0 0 var(--default-clickable-area);
+  opacity: 0.7;
+  background-position: center;
+  background-size: 16px;
+}
+.option__details[data-v-a0f4d73a], .option__lineone[data-v-a0f4d73a], .option__linetwo[data-v-a0f4d73a], .option__icon[data-v-a0f4d73a] {
+  cursor: inherit;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-9ce7ef1d] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.avatardiv[data-v-9ce7ef1d] {
+  position: relative;
+  display: inline-block;
+  width: var(--size);
+  height: var(--size);
+}
+.avatardiv--unknown[data-v-9ce7ef1d] {
+  position: relative;
+  background-color: var(--color-main-background);
+  white-space: normal;
+}
+.avatardiv[data-v-9ce7ef1d]:not(.avatardiv--unknown) {
+  background-color: var(--color-main-background) !important;
+  box-shadow: 0 0 5px rgba(0, 0, 0, 0.05) inset;
+}
+.avatardiv--with-menu[data-v-9ce7ef1d] {
+  cursor: pointer;
+}
+.avatardiv--with-menu .action-item[data-v-9ce7ef1d] {
+  position: absolute;
+  top: 0;
+  left: 0;
+}
+.avatardiv--with-menu[data-v-9ce7ef1d] .action-item__menutoggle {
+  cursor: pointer;
+  opacity: 0;
+}
+.avatardiv--with-menu[data-v-9ce7ef1d]:focus-within .action-item__menutoggle, .avatardiv--with-menu[data-v-9ce7ef1d]:hover .action-item__menutoggle, .avatardiv--with-menu.avatardiv--with-menu-loading[data-v-9ce7ef1d] .action-item__menutoggle {
+  opacity: 1;
+}
+.avatardiv--with-menu:focus-within img[data-v-9ce7ef1d], .avatardiv--with-menu:hover img[data-v-9ce7ef1d], .avatardiv--with-menu.avatardiv--with-menu-loading img[data-v-9ce7ef1d] {
+  opacity: 0.3;
+}
+.avatardiv--with-menu[data-v-9ce7ef1d] .action-item__menutoggle,
+.avatardiv--with-menu img[data-v-9ce7ef1d] {
+  transition: opacity var(--animation-quick);
+}
+.avatardiv--with-menu[data-v-9ce7ef1d]  .button-vue,
+.avatardiv--with-menu[data-v-9ce7ef1d]  .button-vue__icon {
+  height: var(--size);
+  min-height: var(--size);
+  width: var(--size) !important;
+  min-width: var(--size);
+}
+.avatardiv--with-menu[data-v-9ce7ef1d] >  .button-vue, .avatardiv--with-menu[data-v-9ce7ef1d] >  .action-item .button-vue {
+  --button-radius: calc(var(--size) / 2);
+}
+.avatardiv .avatardiv__initials-wrapper[data-v-9ce7ef1d] {
+  display: block;
+  height: var(--size);
+  width: var(--size);
+  background-color: var(--color-main-background);
+  border-radius: calc(var(--size) / 2);
+}
+.avatardiv .avatardiv__initials-wrapper .avatardiv__initials[data-v-9ce7ef1d] {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: block;
+  width: 100%;
+  text-align: center;
+  font-weight: normal;
+}
+.avatardiv img[data-v-9ce7ef1d] {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.avatardiv .material-design-icon[data-v-9ce7ef1d] {
+  width: var(--size);
+  height: var(--size);
+}
+.avatardiv .avatardiv__user-status[data-v-9ce7ef1d] {
+  box-sizing: border-box;
+  position: absolute;
+  right: -4px;
+  bottom: -4px;
+  min-height: 14px;
+  min-width: 14px;
+  max-height: 18px;
+  max-width: 18px;
+  height: 40%;
+  width: 40%;
+  line-height: 1;
+  font-size: clamp(var(--font-size-small), 85%, var(--default-font-size));
+  border: 2px solid var(--color-main-background);
+  background-color: var(--color-main-background);
+  background-repeat: no-repeat;
+  background-size: 16px;
+  background-position: center;
+  border-radius: 50%;
+}
+.acli:hover .avatardiv .avatardiv__user-status[data-v-9ce7ef1d] {
+  border-color: var(--color-background-hover);
+  background-color: var(--color-background-hover);
+}
+.acli.active .avatardiv .avatardiv__user-status[data-v-9ce7ef1d] {
+  border-color: var(--color-primary-element-light);
+  background-color: var(--color-primary-element-light);
+}
+.avatardiv .avatardiv__user-status--icon[data-v-9ce7ef1d] {
+  border: none;
+  background-color: transparent;
+}
+.avatardiv .popovermenu-wrapper[data-v-9ce7ef1d] {
+  position: relative;
+  display: inline-block;
+}
+.avatar-class-icon[data-v-9ce7ef1d] {
+  display: block;
+  border-radius: calc(var(--size) / 2);
+  background-color: var(--color-background-darker);
+  height: 100%;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-30c015f0] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+li.action.active[data-v-30c015f0] {
+  background-color: var(--color-background-hover);
+  border-radius: 6px;
+  padding: 0;
+}
+.action-link[data-v-30c015f0] {
+  display: flex;
+  align-items: flex-start;
+  width: 100%;
+  height: auto;
+  margin: 0;
+  padding: 0;
+  padding-right: calc((var(--default-clickable-area) - 16px) / 2);
+  box-sizing: border-box;
+  cursor: pointer;
+  white-space: nowrap;
+  color: var(--color-main-text);
+  border: 0;
+  border-radius: 0;
+  background-color: transparent;
+  box-shadow: none;
+  font-weight: normal;
+  font-size: var(--default-font-size);
+  line-height: var(--default-clickable-area);
+}
+.action-link > span[data-v-30c015f0] {
+  cursor: pointer;
+  white-space: nowrap;
+}
+.action-link__icon[data-v-30c015f0] {
+  width: var(--default-clickable-area);
+  height: var(--default-clickable-area);
+  opacity: 1;
+  background-position: calc((var(--default-clickable-area) - 16px) / 2) center;
+  background-size: 16px;
+  background-repeat: no-repeat;
+}
+.action-link[data-v-30c015f0] .material-design-icon {
+  width: var(--default-clickable-area);
+  height: var(--default-clickable-area);
+  opacity: 1;
+}
+.action-link[data-v-30c015f0] .material-design-icon .material-design-icon__svg {
+  vertical-align: middle;
+}
+.action-link__longtext-wrapper[data-v-30c015f0], .action-link__longtext[data-v-30c015f0] {
+  max-width: 220px;
+  line-height: 1.6em;
+  padding: calc((var(--default-clickable-area) - 1.6em) / 2) 0;
+  cursor: pointer;
+  text-align: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.action-link__longtext[data-v-30c015f0] {
+  cursor: pointer;
+  white-space: pre-wrap !important;
+}
+.action-link__name[data-v-30c015f0] {
+  font-weight: bold;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  max-width: 100%;
+  display: inline-block;
+}
+.action-link__menu-icon[data-v-30c015f0] {
+  margin-left: auto;
+  margin-right: calc((var(--default-clickable-area) - 16px) / 2 * -1);
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-579c6b4d] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+li.action.active[data-v-579c6b4d] {
+  background-color: var(--color-background-hover);
+  border-radius: 6px;
+  padding: 0;
+}
+.action-router[data-v-579c6b4d] {
+  display: flex;
+  align-items: flex-start;
+  width: 100%;
+  height: auto;
+  margin: 0;
+  padding: 0;
+  padding-right: calc((var(--default-clickable-area) - 16px) / 2);
+  box-sizing: border-box;
+  cursor: pointer;
+  white-space: nowrap;
+  color: var(--color-main-text);
+  border: 0;
+  border-radius: 0;
+  background-color: transparent;
+  box-shadow: none;
+  font-weight: normal;
+  font-size: var(--default-font-size);
+  line-height: var(--default-clickable-area);
+}
+.action-router > span[data-v-579c6b4d] {
+  cursor: pointer;
+  white-space: nowrap;
+}
+.action-router__icon[data-v-579c6b4d] {
+  width: var(--default-clickable-area);
+  height: var(--default-clickable-area);
+  opacity: 1;
+  background-position: calc((var(--default-clickable-area) - 16px) / 2) center;
+  background-size: 16px;
+  background-repeat: no-repeat;
+}
+.action-router[data-v-579c6b4d] .material-design-icon {
+  width: var(--default-clickable-area);
+  height: var(--default-clickable-area);
+  opacity: 1;
+}
+.action-router[data-v-579c6b4d] .material-design-icon .material-design-icon__svg {
+  vertical-align: middle;
+}
+.action-router__longtext-wrapper[data-v-579c6b4d], .action-router__longtext[data-v-579c6b4d] {
+  max-width: 220px;
+  line-height: 1.6em;
+  padding: calc((var(--default-clickable-area) - 1.6em) / 2) 0;
+  cursor: pointer;
+  text-align: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.action-router__longtext[data-v-579c6b4d] {
+  cursor: pointer;
+  white-space: pre-wrap !important;
+}
+.action-router__name[data-v-579c6b4d] {
+  font-weight: bold;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  max-width: 100%;
+  display: inline-block;
+}
+.action-router__menu-icon[data-v-579c6b4d] {
+  margin-left: auto;
+  margin-right: calc((var(--default-clickable-area) - 16px) / 2 * -1);
+}
+.action--disabled[data-v-579c6b4d] {
+  pointer-events: none;
+  opacity: 0.5;
+}
+.action--disabled[data-v-579c6b4d]:hover, .action--disabled[data-v-579c6b4d]:focus {
+  cursor: default;
+  opacity: 0.5;
+}
+.action--disabled *[data-v-579c6b4d] {
+  opacity: 1 !important;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-824615f4] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+li.action.active[data-v-824615f4] {
+  background-color: var(--color-background-hover);
+  border-radius: 6px;
+  padding: 0;
+}
+.action-text[data-v-824615f4] {
+  display: flex;
+  align-items: flex-start;
+  width: 100%;
+  height: auto;
+  margin: 0;
+  padding: 0;
+  padding-right: calc((var(--default-clickable-area) - 16px) / 2);
+  box-sizing: border-box;
+  cursor: pointer;
+  white-space: nowrap;
+  color: var(--color-main-text);
+  border: 0;
+  border-radius: 0;
+  background-color: transparent;
+  box-shadow: none;
+  font-weight: normal;
+  font-size: var(--default-font-size);
+  line-height: var(--default-clickable-area);
+}
+.action-text > span[data-v-824615f4] {
+  cursor: pointer;
+  white-space: nowrap;
+}
+.action-text__icon[data-v-824615f4] {
+  width: var(--default-clickable-area);
+  height: var(--default-clickable-area);
+  opacity: 1;
+  background-position: calc((var(--default-clickable-area) - 16px) / 2) center;
+  background-size: 16px;
+  background-repeat: no-repeat;
+}
+.action-text[data-v-824615f4] .material-design-icon {
+  width: var(--default-clickable-area);
+  height: var(--default-clickable-area);
+  opacity: 1;
+}
+.action-text[data-v-824615f4] .material-design-icon .material-design-icon__svg {
+  vertical-align: middle;
+}
+.action-text__longtext-wrapper[data-v-824615f4], .action-text__longtext[data-v-824615f4] {
+  max-width: 220px;
+  line-height: 1.6em;
+  padding: calc((var(--default-clickable-area) - 1.6em) / 2) 0;
+  cursor: pointer;
+  text-align: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.action-text__longtext[data-v-824615f4] {
+  cursor: pointer;
+  white-space: pre-wrap !important;
+}
+.action-text__name[data-v-824615f4] {
+  font-weight: bold;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  max-width: 100%;
+  display: inline-block;
+}
+.action-text__menu-icon[data-v-824615f4] {
+  margin-left: auto;
+  margin-right: calc((var(--default-clickable-area) - 16px) / 2 * -1);
+}
+.action--disabled[data-v-824615f4] {
+  pointer-events: none;
+  opacity: 0.5;
+}
+.action--disabled[data-v-824615f4]:hover, .action--disabled[data-v-824615f4]:focus {
+  cursor: default;
+  opacity: 0.5;
+}
+.action--disabled *[data-v-824615f4] {
+  opacity: 1 !important;
+}
+.action-text[data-v-824615f4],
+.action-text span[data-v-824615f4] {
+  cursor: default;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-551209a3] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.loading-icon svg[data-v-551209a3] {
+  animation: rotate var(--animation-duration, 0.8s) linear infinite;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-0555d8d0] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.user-status-icon[data-v-0555d8d0] {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-width: 16px;
+  min-height: 16px;
+  max-width: 20px;
+  max-height: 20px;
+}
+.user-status-icon--invisible[data-v-0555d8d0] {
+  filter: var(--background-invert-if-dark);
+}:host,:root{--vs-colors--lightest:rgba(60,60,60,0.26);--vs-colors--light:rgba(60,60,60,0.5);--vs-colors--dark:#333;--vs-colors--darkest:rgba(0,0,0,0.15);--vs-search-input-color:inherit;--vs-search-input-bg:#fff;--vs-search-input-placeholder-color:inherit;--vs-font-size:1rem;--vs-line-height:1.4;--vs-state-disabled-bg:#f8f8f8;--vs-state-disabled-color:var(--vs-colors--light);--vs-state-disabled-controls-color:var(--vs-colors--light);--vs-state-disabled-cursor:not-allowed;--vs-border-color:var(--vs-colors--lightest);--vs-border-width:1px;--vs-border-style:solid;--vs-border-radius:4px;--vs-actions-padding:4px 6px 0 3px;--vs-controls-color:var(--vs-colors--light);--vs-controls-size:1;--vs-controls--deselect-text-shadow:0 1px 0 #fff;--vs-selected-bg:#f0f0f0;--vs-selected-color:var(--vs-colors--dark);--vs-selected-border-color:var(--vs-border-color);--vs-selected-border-style:var(--vs-border-style);--vs-selected-border-width:var(--vs-border-width);--vs-dropdown-bg:#fff;--vs-dropdown-color:inherit;--vs-dropdown-z-index:1000;--vs-dropdown-min-width:160px;--vs-dropdown-max-height:350px;--vs-dropdown-box-shadow:0px 3px 6px 0px var(--vs-colors--darkest);--vs-dropdown-option-bg:#000;--vs-dropdown-option-color:var(--vs-dropdown-color);--vs-dropdown-option-padding:3px 20px;--vs-dropdown-option--active-bg:#136cfb;--vs-dropdown-option--active-color:#fff;--vs-dropdown-option--kb-focus-box-shadow:inset 0px 0px 0px 2px #949494;--vs-dropdown-option--deselect-bg:#fb5858;--vs-dropdown-option--deselect-color:#fff;--vs-transition-timing-function:cubic-bezier(1,-0.115,0.975,0.855);--vs-transition-duration:150ms}.v-select{font-family:inherit;position:relative}.v-select,.v-select *{box-sizing:border-box}:root{--vs-transition-timing-function:cubic-bezier(1,0.5,0.8,1);--vs-transition-duration:0.15s}@-webkit-keyframes vSelectSpinner{0%{transform:rotate(0deg)}to{transform:rotate(1turn)}}@keyframes vSelectSpinner{0%{transform:rotate(0deg)}to{transform:rotate(1turn)}}.vs__fade-enter-active,.vs__fade-leave-active{pointer-events:none;transition:opacity var(--vs-transition-duration) var(--vs-transition-timing-function)}.vs__fade-enter,.vs__fade-leave-to{opacity:0}:root{--vs-disabled-bg:var(--vs-state-disabled-bg);--vs-disabled-color:var(--vs-state-disabled-color);--vs-disabled-cursor:var(--vs-state-disabled-cursor)}.vs--disabled .vs__clear,.vs--disabled .vs__dropdown-toggle,.vs--disabled .vs__open-indicator,.vs--disabled .vs__open-indicator-button,.vs--disabled .vs__search,.vs--disabled .vs__selected{background-color:var(--vs-disabled-bg);cursor:var(--vs-disabled-cursor)}.v-select[dir=rtl] .vs__actions{padding:0 3px 0 6px}.v-select[dir=rtl] .vs__clear{margin-left:6px;margin-right:0}.v-select[dir=rtl] .vs__deselect{margin-left:0;margin-right:2px}.v-select[dir=rtl] .vs__dropdown-menu{text-align:right}.vs__dropdown-toggle{-webkit-appearance:none;-moz-appearance:none;appearance:none;background:var(--vs-search-input-bg);border:var(--vs-border-width) var(--vs-border-style) var(--vs-border-color);border-radius:var(--vs-border-radius);display:flex;padding:0 0 4px;white-space:normal}.vs__selected-options{display:flex;flex-basis:100%;flex-grow:1;flex-wrap:wrap;min-width:0;padding:0 2px;position:relative}.vs__actions{align-items:center;display:flex;padding:var(--vs-actions-padding)}.vs--searchable .vs__dropdown-toggle{cursor:text}.vs--unsearchable .vs__dropdown-toggle{cursor:pointer}.vs--open .vs__dropdown-toggle{border-bottom-color:transparent;border-bottom-left-radius:0;border-bottom-right-radius:0}.vs__open-indicator-button{background-color:transparent;border:0;cursor:pointer;padding:0}.vs__open-indicator{fill:var(--vs-controls-color);transform:scale(var(--vs-controls-size));transition:transform var(--vs-transition-duration) var(--vs-transition-timing-function);transition-timing-function:var(--vs-transition-timing-function)}.vs--open .vs__open-indicator{transform:rotate(180deg) scale(var(--vs-controls-size))}.vs--loading .vs__open-indicator{opacity:0}.vs__clear{fill:var(--vs-controls-color);background-color:transparent;border:0;cursor:pointer;margin-right:8px;padding:0}.vs__dropdown-menu{background:var(--vs-dropdown-bg);border:var(--vs-border-width) var(--vs-border-style) var(--vs-border-color);border-radius:0 0 var(--vs-border-radius) var(--vs-border-radius);border-top-style:none;box-shadow:var(--vs-dropdown-box-shadow);box-sizing:border-box;color:var(--vs-dropdown-color);display:block;left:0;list-style:none;margin:0;max-height:var(--vs-dropdown-max-height);min-width:var(--vs-dropdown-min-width);overflow-y:auto;padding:5px 0;position:absolute;text-align:left;top:calc(100% - var(--vs-border-width));width:100%;z-index:var(--vs-dropdown-z-index)}.vs__no-options{text-align:center}.vs__dropdown-option{clear:both;color:var(--vs-dropdown-option-color);cursor:pointer;display:block;line-height:1.42857143;padding:var(--vs-dropdown-option-padding);white-space:nowrap}.vs__dropdown-option--highlight{background:var(--vs-dropdown-option--active-bg);color:var(--vs-dropdown-option--active-color)}.vs__dropdown-option--kb-focus{box-shadow:var(--vs-dropdown-option--kb-focus-box-shadow)}.vs__dropdown-option--deselect{background:var(--vs-dropdown-option--deselect-bg);color:var(--vs-dropdown-option--deselect-color)}.vs__dropdown-option--disabled{background:var(--vs-state-disabled-bg);color:var(--vs-state-disabled-color);cursor:var(--vs-state-disabled-cursor)}.vs__selected{align-items:center;background-color:var(--vs-selected-bg);border:var(--vs-selected-border-width) var(--vs-selected-border-style) var(--vs-selected-border-color);border-radius:var(--vs-border-radius);color:var(--vs-selected-color);display:flex;line-height:var(--vs-line-height);margin:4px 2px 0;min-width:0;padding:0 .25em;z-index:0}.vs__deselect{fill:var(--vs-controls-color);-webkit-appearance:none;-moz-appearance:none;appearance:none;background:none;border:0;cursor:pointer;display:inline-flex;margin-left:4px;padding:0;text-shadow:var(--vs-controls--deselect-text-shadow)}.vs--single .vs__selected{background-color:transparent;border-color:transparent}.vs--single.vs--loading .vs__selected,.vs--single.vs--open .vs__selected{max-width:100%;opacity:.4;position:absolute}.vs--single.vs--searching .vs__selected{display:none}.vs__search::-webkit-search-cancel-button{display:none}.vs__search::-ms-clear,.vs__search::-webkit-search-decoration,.vs__search::-webkit-search-results-button,.vs__search::-webkit-search-results-decoration{display:none}.vs__search,.vs__search:focus{-webkit-appearance:none;-moz-appearance:none;appearance:none;background:none;border:1px solid transparent;border-left:none;box-shadow:none;color:var(--vs-search-input-color);flex-grow:1;font-size:var(--vs-font-size);line-height:var(--vs-line-height);margin:4px 0 0;max-width:100%;outline:none;padding:0 7px;width:0;z-index:1}.vs__search::-moz-placeholder{color:var(--vs-search-input-placeholder-color)}.vs__search:-ms-input-placeholder{color:var(--vs-search-input-placeholder-color)}.vs__search::placeholder{color:var(--vs-search-input-placeholder-color)}.vs--unsearchable .vs__search{opacity:1}.vs--unsearchable:not(.vs--disabled) .vs__search{cursor:pointer}.vs--single.vs--searching:not(.vs--open):not(.vs--loading) .vs__search{opacity:.2}.vs__spinner{align-self:center;-webkit-animation:vSelectSpinner 1.1s linear infinite;animation:vSelectSpinner 1.1s linear infinite;border:.9em solid hsla(0,0%,39%,.1);border-left-color:rgba(60,60,60,.45);font-size:5px;opacity:0;overflow:hidden;text-indent:-9999em;transform:translateZ(0) scale(var(--vs-controls--spinner-size,var(--vs-controls-size)));transition:opacity .1s}.vs__spinner,.vs__spinner:after{border-radius:50%;height:5em;transform:scale(var(--vs-controls--spinner-size,var(--vs-controls-size)));width:5em}.vs--loading .vs__spinner{opacity:1}
+
+/*# sourceMappingURL=vue-select.css.map*//**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-fbe2ff4a] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.native-datetime-picker[data-v-fbe2ff4a] {
+  display: flex;
+  flex-direction: column;
+}
+.native-datetime-picker .native-datetime-picker--input[data-v-fbe2ff4a] {
+  width: 100%;
+  flex: 0 0 auto;
+  padding-right: 4px;
+}
+[data-theme-light] .native-datetime-picker--input[data-v-fbe2ff4a],
+[data-themes*=light] .native-datetime-picker--input[data-v-fbe2ff4a] {
+  color-scheme: light;
+}
+[data-theme-dark] .native-datetime-picker--input[data-v-fbe2ff4a],
+[data-themes*=dark] .native-datetime-picker--input[data-v-fbe2ff4a] {
+  color-scheme: dark;
+}
+@media (prefers-color-scheme: light) {
+[data-theme-default] .native-datetime-picker--input[data-v-fbe2ff4a],
+  [data-themes*=default] .native-datetime-picker--input[data-v-fbe2ff4a] {
+    color-scheme: light;
+}
+}
+@media (prefers-color-scheme: dark) {
+[data-theme-default] .native-datetime-picker--input[data-v-fbe2ff4a],
+  [data-themes*=default] .native-datetime-picker--input[data-v-fbe2ff4a] {
+    color-scheme: dark;
+}
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-d984b8e5] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+[data-v-d984b8e5] .password-field__input--secure-text {
+  -webkit-text-security: disc;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-374fffac] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.input-field[data-v-374fffac] {
+  --input-border-radius: var(--border-radius-element, var(--border-radius-large));
+  --input-padding-start: var(--border-radius-large);
+  --input-padding-end: var(--border-radius-large);
+  position: relative;
+  width: 100%;
+  margin-block-start: 6px;
+}
+.input-field--disabled[data-v-374fffac] {
+  opacity: 0.4;
+  filter: saturate(0.4);
+}
+.input-field--label-outside[data-v-374fffac] {
+  margin-block-start: 0;
+}
+.input-field--leading-icon[data-v-374fffac] {
+  --input-padding-start: calc(var(--default-clickable-area) - var(--default-grid-baseline));
+}
+.input-field--trailing-icon[data-v-374fffac] {
+  --input-padding-end: calc(var(--default-clickable-area) - var(--default-grid-baseline));
+}
+.input-field--pill[data-v-374fffac] {
+  --input-border-radius: var(--border-radius-pill);
+}
+.input-field__main-wrapper[data-v-374fffac] {
+  height: var(--default-clickable-area);
+  position: relative;
+}
+.input-field__input[data-v-374fffac] {
+  --input-border-width-offset: calc(var(--border-width-input-focused, 2px) - var(--border-width-input, 2px));
+  background-color: var(--color-main-background);
+  color: var(--color-main-text);
+  border: var(--border-width-input, 2px) solid var(--color-border-maxcontrast);
+  border-radius: var(--input-border-radius);
+  cursor: pointer;
+  -webkit-appearance: textfield !important;
+  -moz-appearance: textfield !important;
+  appearance: textfield !important;
+  font-size: var(--default-font-size);
+  text-overflow: ellipsis;
+  height: calc(var(--default-clickable-area) - 2 * var(--input-border-width-offset)) !important;
+  width: 100%;
+  padding-inline: calc(var(--input-padding-start) + var(--input-border-width-offset)) calc(var(--input-padding-end) + var(--input-border-width-offset));
+  padding-block: var(--input-border-width-offset);
+}
+.input-field__input[data-v-374fffac]::placeholder {
+  color: var(--color-text-maxcontrast);
+}
+.input-field__input[data-v-374fffac]:active:not([disabled]), .input-field__input[data-v-374fffac]:hover:not([disabled]), .input-field__input[data-v-374fffac]:focus:not([disabled]) {
+  border-color: var(--color-main-text);
+  border-width: var(--border-width-input-focused, 2px);
+  box-shadow: 0 0 0 2px var(--color-main-background) !important;
+  --input-border-width-offset: 0px;
+}
+.input-field__input:focus + .input-field__label[data-v-374fffac], .input-field__input:hover:not(:placeholder-shown) + .input-field__label[data-v-374fffac] {
+  color: var(--color-main-text);
+}
+.input-field__input[data-v-374fffac]:focus {
+  cursor: text;
+}
+.input-field__input[data-v-374fffac]:disabled {
+  cursor: default;
+}
+.input-field__input[data-v-374fffac]:focus-visible {
+  box-shadow: unset !important;
+}
+.input-field__input--success[data-v-374fffac] {
+  border-color: var(--color-success) !important;
+}
+.input-field__input--success[data-v-374fffac]:focus-visible {
+  box-shadow: rgb(248, 250, 252) 0px 0px 0px 2px, var(--color-primary-element) 0px 0px 0px 4px, rgba(0, 0, 0, 0.05) 0px 1px 2px 0px;
+}
+.input-field__input--error[data-v-374fffac], .input-field__input[data-v-374fffac]:invalid {
+  border-color: var(--color-error) !important;
+}
+.input-field__input--error[data-v-374fffac]:focus-visible, .input-field__input[data-v-374fffac]:invalid:focus-visible {
+  box-shadow: rgb(248, 250, 252) 0px 0px 0px 2px, var(--color-primary-element) 0px 0px 0px 4px, rgba(0, 0, 0, 0.05) 0px 1px 2px 0px;
+}
+.input-field:not(.input-field--label-outside) .input-field__input[data-v-374fffac]:not(:focus)::placeholder {
+  opacity: 0;
+}
+.input-field__label[data-v-374fffac] {
+  --input-label-font-size: var(--default-font-size);
+  position: absolute;
+  margin-inline: var(--input-padding-start) var(--input-padding-end);
+  max-width: fit-content;
+  font-size: var(--input-label-font-size);
+  inset-block-start: calc((var(--default-clickable-area) - 1lh) / 2);
+  inset-inline: var(--border-width-input-focused, 2px);
+  color: var(--color-text-maxcontrast);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  pointer-events: none;
+  transition: height var(--animation-quick), inset-block-start var(--animation-quick), font-size var(--animation-quick), color var(--animation-quick), background-color var(--animation-quick) var(--animation-slow);
+}
+.input-field__input:focus + .input-field__label[data-v-374fffac], .input-field__input:not(:placeholder-shown) + .input-field__label[data-v-374fffac] {
+  --input-label-font-size: 13px;
+  line-height: 1.5;
+  inset-block-start: calc(-1.5 * var(--input-label-font-size) / 2);
+  font-weight: 500;
+  border-radius: var(--default-grid-baseline) var(--default-grid-baseline) 0 0;
+  background-color: var(--color-main-background);
+  padding-inline: var(--default-grid-baseline);
+  margin-inline: calc(var(--input-padding-start) - var(--default-grid-baseline)) calc(var(--input-padding-end) - var(--default-grid-baseline));
+  transition: height var(--animation-quick), inset-block-start var(--animation-quick), font-size var(--animation-quick), color var(--animation-quick);
+}
+.input-field__icon[data-v-374fffac] {
+  position: absolute;
+  height: var(--default-clickable-area);
+  width: var(--default-clickable-area);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0.7;
+  inset-block-end: 0;
+}
+.input-field__icon--leading[data-v-374fffac] {
+  inset-inline-start: 0px;
+}
+.input-field__icon--trailing[data-v-374fffac] {
+  inset-inline-end: 0px;
+}
+.input-field__trailing-button[data-v-374fffac] {
+  --button-size: calc(var(--default-clickable-area) - 2 * var(--border-width-input-focused, 2px)) !important;
+  --button-radius: calc(var(--input-border-radius) - var(--border-width-input-focused, 2px));
+}
+.input-field__trailing-button.button-vue[data-v-374fffac] {
+  position: absolute;
+  top: var(--border-width-input-focused, 2px);
+  right: var(--border-width-input-focused, 2px);
+}
+.input-field__trailing-button.button-vue[data-v-374fffac]:focus-visible {
+  box-shadow: none !important;
+}
+.input-field__helper-text-message[data-v-374fffac] {
+  padding-block: 4px;
+  padding-inline: var(--border-radius-large);
+  display: flex;
+  align-items: center;
+  color: var(--color-text-maxcontrast);
+}
+.input-field__helper-text-message__icon[data-v-374fffac] {
+  margin-inline-end: 8px;
+}
+.input-field__helper-text-message--error[data-v-374fffac] {
+  color: var(--color-error-text);
+}
+.input-field__helper-text-message--success[data-v-374fffac] {
+  color: var(--color-success-text);
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-8c1a9122] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+li.action.active[data-v-8c1a9122] {
+  background-color: var(--color-background-hover);
+  border-radius: 6px;
+  padding: 0;
+}
+.action--disabled[data-v-8c1a9122] {
+  pointer-events: none;
+  opacity: 0.5;
+}
+.action--disabled[data-v-8c1a9122]:hover, .action--disabled[data-v-8c1a9122]:focus {
+  cursor: default;
+  opacity: 0.5;
+}
+.action--disabled *[data-v-8c1a9122] {
+  opacity: 1 !important;
+}
+.action-radio[data-v-8c1a9122] {
+  display: flex;
+  align-items: flex-start;
+  width: 100%;
+  height: auto;
+  margin: 0;
+  padding: 0;
+  cursor: pointer;
+  white-space: nowrap;
+  color: var(--color-main-text);
+  border: 0;
+  border-radius: 0;
+  background-color: transparent;
+  box-shadow: none;
+  font-weight: normal;
+  line-height: var(--default-clickable-area);
+  /* checkbox/radio fixes */
+}
+.action-radio__radio[data-v-8c1a9122] {
+  position: absolute;
+  top: auto;
+  left: -10000px;
+  overflow: hidden;
+  width: 1px;
+  height: 1px;
+}
+.action-radio__label[data-v-8c1a9122] {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  padding: 0 !important;
+  padding-right: calc((var(--default-clickable-area) - 16px) / 2) !important;
+}
+.action-radio__label[data-v-8c1a9122]::before {
+  margin: calc((var(--default-clickable-area) - 14px) / 2) !important;
+}
+.action-radio--disabled[data-v-8c1a9122],
+.action-radio--disabled .action-radio__label[data-v-8c1a9122] {
+  cursor: pointer;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-3e2324b7] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.action-separator[data-v-3e2324b7] {
+  height: 0;
+  margin: 5px 10px 5px 15px;
+  border-bottom: 1px solid var(--color-border-dark);
+  cursor: default;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-c9d92b93] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * color-text-lighter		normal state
+ * color-text-lighter		active state
+ * color-text-maxcontrast 	disabled state
+ */
+/* Default global values */
+button[data-v-c9d92b93]:not(.button-vue),
+input[data-v-c9d92b93]:not([type=range]),
+textarea[data-v-c9d92b93] {
+  margin: 0;
+  padding: 7px 6px;
+  cursor: text;
+  color: var(--color-text-lighter);
+  border: 1px solid var(--color-border-dark);
+  border-radius: var(--border-radius);
+  outline: none;
+  background-color: var(--color-main-background);
+  font-size: 13px;
+  /* Primary action button, use sparingly */
+}
+button[data-v-c9d92b93]:not(.button-vue):not(:disabled):not(.primary):hover, button[data-v-c9d92b93]:not(.button-vue):not(:disabled):not(.primary):focus, button:not(.button-vue):not(:disabled):not(.primary).active[data-v-c9d92b93],
+input[data-v-c9d92b93]:not([type=range]):not(:disabled):not(.primary):hover,
+input[data-v-c9d92b93]:not([type=range]):not(:disabled):not(.primary):focus,
+input:not([type=range]):not(:disabled):not(.primary).active[data-v-c9d92b93],
+textarea[data-v-c9d92b93]:not(:disabled):not(.primary):hover,
+textarea[data-v-c9d92b93]:not(:disabled):not(.primary):focus,
+textarea:not(:disabled):not(.primary).active[data-v-c9d92b93] {
+  /* active class used for multiselect */
+  border-color: var(--color-primary-element);
+  outline: none;
+}
+button[data-v-c9d92b93]:not(.button-vue):not(:disabled):not(.primary):active,
+input[data-v-c9d92b93]:not([type=range]):not(:disabled):not(.primary):active,
+textarea[data-v-c9d92b93]:not(:disabled):not(.primary):active {
+  color: var(--color-text-light);
+  outline: none;
+  background-color: var(--color-main-background);
+}
+button[data-v-c9d92b93]:not(.button-vue):disabled,
+input[data-v-c9d92b93]:not([type=range]):disabled,
+textarea[data-v-c9d92b93]:disabled {
+  cursor: default;
+  opacity: 0.5;
+  color: var(--color-text-maxcontrast);
+  background-color: var(--color-background-dark);
+}
+button[data-v-c9d92b93]:not(.button-vue):required,
+input[data-v-c9d92b93]:not([type=range]):required,
+textarea[data-v-c9d92b93]:required {
+  box-shadow: none;
+}
+button[data-v-c9d92b93]:not(.button-vue):invalid,
+input[data-v-c9d92b93]:not([type=range]):invalid,
+textarea[data-v-c9d92b93]:invalid {
+  border-color: var(--color-error);
+  box-shadow: none !important;
+}
+button:not(.button-vue).primary[data-v-c9d92b93],
+input:not([type=range]).primary[data-v-c9d92b93],
+textarea.primary[data-v-c9d92b93] {
+  cursor: pointer;
+  color: var(--color-primary-element-text);
+  border-color: var(--color-primary-element);
+  background-color: var(--color-primary-element);
+}
+button:not(.button-vue).primary[data-v-c9d92b93]:not(:disabled):hover, button:not(.button-vue).primary[data-v-c9d92b93]:not(:disabled):focus, button:not(.button-vue).primary[data-v-c9d92b93]:not(:disabled):active,
+input:not([type=range]).primary[data-v-c9d92b93]:not(:disabled):hover,
+input:not([type=range]).primary[data-v-c9d92b93]:not(:disabled):focus,
+input:not([type=range]).primary[data-v-c9d92b93]:not(:disabled):active,
+textarea.primary[data-v-c9d92b93]:not(:disabled):hover,
+textarea.primary[data-v-c9d92b93]:not(:disabled):focus,
+textarea.primary[data-v-c9d92b93]:not(:disabled):active {
+  border-color: var(--color-primary-element-light);
+  background-color: var(--color-primary-element-light);
+}
+button:not(.button-vue).primary[data-v-c9d92b93]:not(:disabled):active,
+input:not([type=range]).primary[data-v-c9d92b93]:not(:disabled):active,
+textarea.primary[data-v-c9d92b93]:not(:disabled):active {
+  color: var(--color-primary-element-text-dark);
+}
+button:not(.button-vue).primary[data-v-c9d92b93]:disabled,
+input:not([type=range]).primary[data-v-c9d92b93]:disabled,
+textarea.primary[data-v-c9d92b93]:disabled {
+  cursor: default;
+  color: var(--color-primary-element-text-dark);
+  background-color: var(--color-primary-element);
+}
+/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+li.action.active[data-v-c9d92b93] {
+  background-color: var(--color-background-hover);
+  border-radius: 6px;
+  padding: 0;
+}
+.action--disabled[data-v-c9d92b93] {
+  pointer-events: none;
+  opacity: 0.5;
+}
+.action--disabled[data-v-c9d92b93]:hover, .action--disabled[data-v-c9d92b93]:focus {
+  cursor: default;
+  opacity: 0.5;
+}
+.action--disabled *[data-v-c9d92b93] {
+  opacity: 1 !important;
+}
+.action-text-editable[data-v-c9d92b93] {
+  display: flex;
+  align-items: flex-start;
+  width: 100%;
+  height: auto;
+  margin: 0;
+  padding: 0;
+  cursor: pointer;
+  white-space: nowrap;
+  color: var(--color-main-text);
+  border: 0;
+  border-radius: 0;
+  background-color: transparent;
+  box-shadow: none;
+  font-weight: normal;
+  line-height: var(--default-clickable-area);
+  /* Inputs inside popover supports text, submit & reset */
+}
+.action-text-editable > span[data-v-c9d92b93] {
+  cursor: pointer;
+  white-space: nowrap;
+}
+.action-text-editable__icon[data-v-c9d92b93] {
+  min-width: 0; /* Overwrite icons*/
+  min-height: 0;
+  /* Keep padding to define the width to
+  	assure correct position of a possible text */
+  padding: calc(var(--default-clickable-area) / 2) 0 calc(var(--default-clickable-area) / 2) var(--default-clickable-area);
+  background-position: calc((var(--default-clickable-area) - 16px) / 2) center;
+  background-size: 16px;
+}
+.action-text-editable[data-v-c9d92b93] .material-design-icon {
+  width: var(--default-clickable-area);
+  height: var(--default-clickable-area);
+  opacity: 1;
+}
+.action-text-editable[data-v-c9d92b93] .material-design-icon .material-design-icon__svg {
+  vertical-align: middle;
+}
+.action-text-editable__form[data-v-c9d92b93] {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  position: relative;
+  margin: 4px 0;
+  padding-right: calc((var(--default-clickable-area) - 16px) / 2);
+}
+.action-text-editable__submit[data-v-c9d92b93] {
+  position: absolute;
+  left: -10000px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+.action-text-editable__label[data-v-c9d92b93] {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  right: calc((var(--default-clickable-area) - 16px) / 2 + 1);
+  bottom: 1px;
+  width: calc(var(--default-clickable-area) - 8px);
+  height: calc(var(--default-clickable-area) - 8px);
+  box-sizing: border-box;
+  margin: 0;
+  padding: 7px 6px;
+  border: 0;
+  border-radius: 50%;
+  /* Avoid background under border */
+  background-color: var(--color-main-background);
+  background-clip: padding-box;
+}
+.action-text-editable__label[data-v-c9d92b93], .action-text-editable__label *[data-v-c9d92b93] {
+  cursor: pointer;
+}
+.action-text-editable__textarea[data-v-c9d92b93] {
+  flex: 1 1 auto;
+  color: inherit;
+  border-color: var(--color-border-maxcontrast);
+  min-height: calc(var(--default-clickable-area) * 2 - 8px); /* twice the element margin-y */
+  max-height: calc(var(--default-clickable-area) * 3 - 8px); /* twice the element margin-y */
+  min-width: calc(var(--default-clickable-area) * 4);
+  width: 100% !important;
+  margin: 0;
+  /* only show confirm borders if input is not focused */
+}
+.action-text-editable__textarea[data-v-c9d92b93]:disabled {
+  cursor: default;
+}
+.action-text-editable__textarea:not(:active):not(:hover):not(:focus):invalid + .action-text-editable__label[data-v-c9d92b93] {
+  background-color: var(--color-error);
+}
+.action-text-editable__textarea:not(:active):not(:hover):not(:focus):not(:disabled) + .action-text-editable__label[data-v-c9d92b93]:active, .action-text-editable__textarea:not(:active):not(:hover):not(:focus):not(:disabled) + .action-text-editable__label[data-v-c9d92b93]:hover, .action-text-editable__textarea:not(:active):not(:hover):not(:focus):not(:disabled) + .action-text-editable__label[data-v-c9d92b93]:focus {
+  background-color: var(--color-primary-element);
+  color: var(--color-primary-element-text);
+}
+.action-text-editable__textarea:active:not(:disabled) + .action-text-editable__label[data-v-c9d92b93], .action-text-editable__textarea:hover:not(:disabled) + .action-text-editable__label[data-v-c9d92b93], .action-text-editable__textarea:focus:not(:disabled) + .action-text-editable__label[data-v-c9d92b93] {
+  /* above previous input */
+  z-index: 2;
+  border-color: var(--color-primary-element);
+  border-left-color: transparent;
+}
+li:last-child > .action-text-editable[data-v-c9d92b93] {
+  margin-bottom: calc((var(--default-clickable-area) - 16px) / 2 - 4px);
+}
+li:first-child > .action-text-editable[data-v-c9d92b93] {
+  margin-top: calc((var(--default-clickable-area) - 16px) / 2 - 4px);
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-7692fc78] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.app-details-toggle[data-v-7692fc78] {
+  position: sticky;
+  width: var(--default-clickable-area);
+  height: var(--default-clickable-area);
+  padding: calc((var(--default-clickable-area) - 16px) / 2);
+  cursor: pointer;
+  opacity: 0.6;
+  transform: rotate(180deg);
+  background-color: var(--color-main-background);
+  z-index: 2000;
+  top: var(--app-navigation-padding);
+  left: calc(var(--default-clickable-area) + var(--app-navigation-padding) * 2);
+}
+.app-details-toggle--mobile[data-v-7692fc78] {
+  left: var(--app-navigation-padding);
+}
+.app-details-toggle[data-v-7692fc78]:active, .app-details-toggle[data-v-7692fc78]:hover, .app-details-toggle[data-v-7692fc78]:focus {
+  opacity: 1;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-de6986e3] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.app-content[data-v-de6986e3] {
+  position: initial;
+  z-index: 1000;
+  flex-basis: 100vw;
+  height: 100%;
+  margin: 0 !important;
+  background-color: var(--color-main-background);
+  min-width: 0;
+}
+.app-content[data-v-de6986e3]:not(.app-content--has-list) {
+  overflow: auto;
+}
+.app-content-wrapper[data-v-de6986e3] {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+.app-content-wrapper--no-split.app-content-wrapper--show-list[data-v-de6986e3]  .app-content-list {
+  display: flex;
+}
+.app-content-wrapper--no-split.app-content-wrapper--show-list[data-v-de6986e3]  .app-content-details {
+  display: none;
+}
+.app-content-wrapper--no-split.app-content-wrapper--show-details[data-v-de6986e3]  .app-content-list {
+  display: none;
+}
+.app-content-wrapper--no-split.app-content-wrapper--show-details[data-v-de6986e3]  .app-content-details {
+  display: block;
+}
+[data-v-de6986e3] .splitpanes.default-theme .app-content-list {
+  max-width: none;
+  /* Thin scrollbar is hard to catch on resizable columns */
+  scrollbar-width: auto;
+}
+[data-v-de6986e3] .splitpanes.default-theme .splitpanes__pane {
+  background-color: transparent;
+  transition: none;
+}
+[data-v-de6986e3] .splitpanes.default-theme .splitpanes__pane-list {
+  min-width: 300px;
+  position: sticky;
+}
+@media only screen and (width < 1024px) {
+[data-v-de6986e3] .splitpanes.default-theme .splitpanes__pane-list {
+    display: none;
+}
+}
+[data-v-de6986e3] .splitpanes.default-theme .splitpanes__pane-details {
+  overflow-y: auto;
+}
+@media only screen and (width < 1024px) {
+[data-v-de6986e3] .splitpanes.default-theme .splitpanes__pane-details {
+    min-width: 100%;
+}
+}
+[data-v-de6986e3] .splitpanes.default-theme.splitpanes--vertical .splitpanes__splitter {
+  background-color: var(--color-main-background);
+  border-left: 1px solid var(--color-border);
+}
+[data-v-de6986e3] .splitpanes.default-theme.splitpanes--vertical .splitpanes__splitter::before,[data-v-de6986e3] .splitpanes.default-theme.splitpanes--vertical .splitpanes__splitter::after {
+  background-color: var(--color-border);
+}
+.app-content-wrapper--show-list[data-v-de6986e3] .app-content-list {
+  max-width: none;
+}.splitpanes{display:-webkit-box;display:-ms-flexbox;display:flex;width:100%;height:100%}.splitpanes--vertical{-webkit-box-orient:horizontal;-webkit-box-direction:normal;-ms-flex-direction:row;flex-direction:row}.splitpanes--horizontal{-webkit-box-orient:vertical;-webkit-box-direction:normal;-ms-flex-direction:column;flex-direction:column}.splitpanes--dragging *{-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}.splitpanes__pane{width:100%;height:100%;overflow:hidden}.splitpanes--vertical .splitpanes__pane{-webkit-transition:width .2s ease-out;-o-transition:width .2s ease-out;transition:width .2s ease-out}.splitpanes--horizontal .splitpanes__pane{-webkit-transition:height .2s ease-out;-o-transition:height .2s ease-out;transition:height .2s ease-out}.splitpanes--dragging .splitpanes__pane{-webkit-transition:none;-o-transition:none;transition:none}.splitpanes__splitter{-ms-touch-action:none;touch-action:none}.splitpanes--vertical>.splitpanes__splitter{min-width:1px;cursor:col-resize}.splitpanes--horizontal>.splitpanes__splitter{min-height:1px;cursor:row-resize}.splitpanes.default-theme .splitpanes__pane{background-color:#f2f2f2}.splitpanes.default-theme .splitpanes__splitter{background-color:#fff;-webkit-box-sizing:border-box;box-sizing:border-box;position:relative;-ms-flex-negative:0;flex-shrink:0}.splitpanes.default-theme .splitpanes__splitter:before,.splitpanes.default-theme .splitpanes__splitter:after{content:"";position:absolute;top:50%;left:50%;background-color:#00000026;-webkit-transition:background-color .3s;-o-transition:background-color .3s;transition:background-color .3s}.splitpanes.default-theme .splitpanes__splitter:hover:before,.splitpanes.default-theme .splitpanes__splitter:hover:after{background-color:#00000040}.splitpanes.default-theme .splitpanes__splitter:first-child{cursor:auto}.default-theme.splitpanes .splitpanes .splitpanes__splitter{z-index:1}.default-theme.splitpanes--vertical>.splitpanes__splitter,.default-theme .splitpanes--vertical>.splitpanes__splitter{width:7px;border-left:1px solid #eee;margin-left:-1px}.default-theme.splitpanes--vertical>.splitpanes__splitter:before,.default-theme.splitpanes--vertical>.splitpanes__splitter:after,.default-theme .splitpanes--vertical>.splitpanes__splitter:before,.default-theme .splitpanes--vertical>.splitpanes__splitter:after{-webkit-transform:translateY(-50%);-ms-transform:translateY(-50%);transform:translateY(-50%);width:1px;height:30px}.default-theme.splitpanes--vertical>.splitpanes__splitter:before,.default-theme .splitpanes--vertical>.splitpanes__splitter:before{margin-left:-2px}.default-theme.splitpanes--vertical>.splitpanes__splitter:after,.default-theme .splitpanes--vertical>.splitpanes__splitter:after{margin-left:1px}.default-theme.splitpanes--horizontal>.splitpanes__splitter,.default-theme .splitpanes--horizontal>.splitpanes__splitter{height:7px;border-top:1px solid #eee;margin-top:-1px}.default-theme.splitpanes--horizontal>.splitpanes__splitter:before,.default-theme.splitpanes--horizontal>.splitpanes__splitter:after,.default-theme .splitpanes--horizontal>.splitpanes__splitter:before,.default-theme .splitpanes--horizontal>.splitpanes__splitter:after{-webkit-transform:translateX(-50%);-ms-transform:translateX(-50%);transform:translate(-50%);width:30px;height:1px}.default-theme.splitpanes--horizontal>.splitpanes__splitter:before,.default-theme .splitpanes--horizontal>.splitpanes__splitter:before{margin-top:-2px}.default-theme.splitpanes--horizontal>.splitpanes__splitter:after,.default-theme .splitpanes--horizontal>.splitpanes__splitter:after{margin-top:1px}
+/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.app-navigation,
+.app-content {
+  /** Distance of the app navigation toggle and the first navigation item to the top edge of the app content container */
+  --app-navigation-padding: calc(var(--default-grid-baseline, 4px) * 2);
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-1c2985af] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.app-navigation[data-v-1c2985af] {
+  --color-text-maxcontrast: var(--color-text-maxcontrast-background-blur, var(--color-text-maxcontrast-default));
+  transition: transform var(--animation-quick), margin var(--animation-quick);
+  width: 300px;
+  --app-navigation-max-width: calc(100vw - (var(--app-navigation-padding) + var(--default-clickable-area) + var(--default-grid-baseline)));
+  max-width: var(--app-navigation-max-width);
+  position: relative;
+  top: 0;
+  left: 0;
+  padding: 0px;
+  z-index: 1800;
+  height: 100%;
+  box-sizing: border-box;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  flex-grow: 0;
+  flex-shrink: 0;
+  background-color: var(--color-main-background-blur, var(--color-main-background));
+  -webkit-backdrop-filter: var(--filter-background-blur, none);
+  backdrop-filter: var(--filter-background-blur, none);
+  border-inline-end: 1px solid var(--color-border);
+}
+.app-navigation--close[data-v-1c2985af] {
+  margin-left: calc(-1 * min(300px, var(--app-navigation-max-width)));
+}
+.app-navigation__search[data-v-1c2985af] {
+  width: 100%;
+}
+.app-navigation__body[data-v-1c2985af] {
+  overflow-y: scroll;
+}
+.app-navigation__content > ul[data-v-1c2985af] {
+  position: relative;
+  width: 100%;
+  overflow-x: hidden;
+  overflow-y: auto;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: var(--default-grid-baseline, 4px);
+  padding: var(--app-navigation-padding);
+}
+.app-navigation .app-navigation__list[data-v-1c2985af] {
+  height: 100%;
+}
+.app-navigation__body--no-list[data-v-1c2985af] {
+  flex: 1 1 auto;
+  overflow: auto;
+  height: 100%;
+}
+.app-navigation__content[data-v-1c2985af] {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+@media only screen and (max-width: 1024px) {
+.app-navigation[data-v-1c2985af] {
+    position: absolute;
+}
+}
+@media only screen and (max-width: 512px) {
+.app-navigation[data-v-1c2985af] {
+    z-index: 1400;
+}
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-058e6060] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.app-navigation-list[data-v-058e6060] {
+  position: relative;
+  width: 100%;
+  overflow-x: hidden;
+  overflow-y: auto;
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  gap: var(--default-grid-baseline, 4px);
+  padding: var(--app-navigation-padding);
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-b6024aba] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.app-navigation-toggle-wrapper[data-v-b6024aba] {
+  position: absolute;
+  top: var(--app-navigation-padding);
+  right: calc(0px - var(--app-navigation-padding));
+  margin-right: calc(-1 * var(--default-clickable-area));
+}
+button.app-navigation-toggle[data-v-b6024aba] {
+  background-color: var(--color-main-background);
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-af6cfb9c] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.app-navigation-caption[data-v-af6cfb9c] {
+  display: flex;
+  justify-content: space-between;
+}
+.app-navigation-caption--heading[data-v-af6cfb9c] {
+  padding: var(--app-navigation-padding);
+}
+.app-navigation-caption--heading[data-v-af6cfb9c]:not(:first-child):not(:last-child) {
+  padding: 0 var(--app-navigation-padding);
+}
+.app-navigation-caption__name[data-v-af6cfb9c] {
+  font-weight: bold;
+  color: var(--color-main-text);
+  font-size: var(--default-font-size);
+  line-height: var(--default-clickable-area);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  box-shadow: none !important;
+  flex-shrink: 1;
+  padding: 0 calc(var(--default-grid-baseline, 4px) * 2) 0 calc(var(--default-grid-baseline, 4px) * 2);
+  padding-right: 0;
+  margin-top: 0px;
+  margin-bottom: var(--default-grid-baseline);
+}
+.app-navigation-caption__actions[data-v-af6cfb9c] {
+  flex: 0 0 var(--default-clickable-area);
+}
+.app-navigation-caption[data-v-af6cfb9c]:not(:first-child) {
+  margin-top: calc(var(--default-clickable-area) / 2);
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-938dadb1] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.app-navigation-entry__icon-bullet[data-v-938dadb1] {
+  display: block;
+  padding: calc((var(--default-clickable-area) - 16px) / 2 + 1px);
+}
+.app-navigation-entry__icon-bullet div[data-v-938dadb1] {
+  width: 14px;
+  height: 14px;
+  cursor: pointer;
+  transition: background 100ms ease-in-out;
+  border: none;
+  border-radius: 50%;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-cadd59ae] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.button-vue.icon-collapse[data-v-cadd59ae] {
+  position: relative;
+  z-index: 105;
+  color: var(--color-main-text);
+  right: 0;
+}
+.button-vue.icon-collapse--open[data-v-cadd59ae] {
+  color: var(--color-main-text);
+}
+.button-vue.icon-collapse--open[data-v-cadd59ae]:hover {
+  color: var(--color-primary-element);
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-018c4203] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+/**
+ * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+.app-navigation-entry[data-v-018c4203] {
+  position: relative;
+  display: flex;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+  box-sizing: border-box;
+  width: 100%;
+  min-height: var(--default-clickable-area);
+  transition: background-color var(--animation-quick) ease-in-out;
+  transition: background-color 200ms ease-in-out;
+  border-radius: var(--border-radius-element, var(--border-radius-pill));
+  /* hide deletion/collapse of subitems */
+}
+.app-navigation-entry-wrapper[data-v-018c4203] {
+  position: relative;
+  display: flex;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+  box-sizing: border-box;
+  width: 100%;
+}
+.app-navigation-entry-wrapper.app-navigation-entry--collapsible:not(.app-navigation-entry--opened) > ul[data-v-018c4203] {
+  display: none;
+}
+.app-navigation-entry.active[data-v-018c4203] {
+  background-color: var(--color-primary-element) !important;
+}
+.app-navigation-entry.active[data-v-018c4203]:hover {
+  background-color: var(--color-primary-element-hover) !important;
+}
+.app-navigation-entry.active .app-navigation-entry-link[data-v-018c4203], .app-navigation-entry.active .app-navigation-entry-button[data-v-018c4203] {
+  color: var(--color-primary-element-text) !important;
+}
+.app-navigation-entry[data-v-018c4203]:focus-within, .app-navigation-entry[data-v-018c4203]:hover {
+  background-color: var(--color-background-hover);
+}
+.app-navigation-entry.active .app-navigation-entry__children[data-v-018c4203], .app-navigation-entry:focus-within .app-navigation-entry__children[data-v-018c4203], .app-navigation-entry:hover .app-navigation-entry__children[data-v-018c4203] {
+  background-color: var(--color-main-background);
+}
+.app-navigation-entry.active .app-navigation-entry__utils .app-navigation-entry__actions[data-v-018c4203], .app-navigation-entry.app-navigation-entry--deleted .app-navigation-entry__utils .app-navigation-entry__actions[data-v-018c4203], .app-navigation-entry:focus .app-navigation-entry__utils .app-navigation-entry__actions[data-v-018c4203], .app-navigation-entry:focus-within .app-navigation-entry__utils .app-navigation-entry__actions[data-v-018c4203], .app-navigation-entry:hover .app-navigation-entry__utils .app-navigation-entry__actions[data-v-018c4203] {
+  display: inline-block;
+}
+.app-navigation-entry.app-navigation-entry--deleted > ul[data-v-018c4203] {
+  display: none;
+}
+.app-navigation-entry:not(.app-navigation-entry--editing) .app-navigation-entry-link[data-v-018c4203], .app-navigation-entry:not(.app-navigation-entry--editing) .app-navigation-entry-button[data-v-018c4203] {
+  padding-right: calc((var(--default-clickable-area) - 16px) / 2);
+}
+.app-navigation-entry .app-navigation-entry-link[data-v-018c4203], .app-navigation-entry .app-navigation-entry-button[data-v-018c4203] {
+  z-index: 100; /* above the bullet to allow click*/
+  display: flex;
+  overflow: hidden;
+  flex: 1 1 0;
+  box-sizing: border-box;
+  min-height: var(--default-clickable-area);
+  padding: 0;
+  white-space: nowrap;
+  color: var(--color-main-text);
+  background-repeat: no-repeat;
+  background-position: calc((var(--default-clickable-area) - 16px) / 2) center;
+  background-size: 16px 16px;
+  line-height: var(--default-clickable-area);
+}
+.app-navigation-entry .app-navigation-entry-link .app-navigation-entry-icon[data-v-018c4203], .app-navigation-entry .app-navigation-entry-button .app-navigation-entry-icon[data-v-018c4203] {
+  display: flex;
+  align-items: center;
+  flex: 0 0 var(--default-clickable-area);
+  justify-content: center;
+  width: var(--default-clickable-area);
+  height: var(--default-clickable-area);
+  background-size: 16px 16px;
+  background-repeat: no-repeat;
+  background-position: calc((var(--default-clickable-area) - 16px) / 2) center;
+}
+.app-navigation-entry .app-navigation-entry-link .app-navigation-entry__name[data-v-018c4203], .app-navigation-entry .app-navigation-entry-button .app-navigation-entry__name[data-v-018c4203] {
+  overflow: hidden;
+  max-width: 100%;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+.app-navigation-entry .app-navigation-entry-link .editingContainer[data-v-018c4203], .app-navigation-entry .app-navigation-entry-button .editingContainer[data-v-018c4203] {
+  width: calc(100% - var(--default-clickable-area));
+  margin: auto;
+}
+.app-navigation-entry .app-navigation-entry-link[data-v-018c4203]:focus-visible, .app-navigation-entry .app-navigation-entry-button[data-v-018c4203]:focus-visible {
+  box-shadow: 0 0 0 4px var(--color-main-background);
+  outline: 2px solid var(--color-main-text);
+  border-radius: var(--border-radius-element, var(--border-radius-pill));
+}
+/* Second level nesting for lists */
+.app-navigation-entry__children[data-v-018c4203] {
+  position: relative;
+  display: flex;
+  flex: 0 1 auto;
+  flex-direction: column;
+  width: 100%;
+  gap: var(--default-grid-baseline, 4px);
+}
+.app-navigation-entry__children .app-navigation-entry[data-v-018c4203] {
+  display: inline-flex;
+  flex-wrap: wrap;
+  padding-left: 16px;
+}
+/* Deleted entries */
+.app-navigation-entry__deleted[data-v-018c4203] {
+  display: inline-flex;
+  flex: 1 1 0;
+  padding-left: calc(var(--default-clickable-area) - (var(--default-clickable-area) - 16px) / 2) !important;
+}
+.app-navigation-entry__deleted .app-navigation-entry__deleted-description[data-v-018c4203] {
+  position: relative;
+  overflow: hidden;
+  flex: 1 1 0;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  line-height: var(--default-clickable-area);
+}
+/* counter and actions */
+.app-navigation-entry__utils[data-v-018c4203] {
+  display: flex;
+  min-width: var(--default-clickable-area);
+  align-items: center;
+  flex: 0 1 auto;
+  justify-content: flex-end;
+  /* counter */
+  /* actions */
+}
+.app-navigation-entry__utils.app-navigation-entry__utils--display-actions .action-item.app-navigation-entry__actions[data-v-018c4203] {
+  display: inline-block;
+}
+.app-navigation-entry__utils .app-navigation-entry__counter-wrapper[data-v-018c4203] {
+  margin-right: calc(var(--default-grid-baseline) * 3);
+  display: flex;
+  align-items: center;
+  flex: 0 1 auto;
+}
+.app-navigation-entry__utils .action-item.app-navigation-entry__actions[data-v-018c4203] {
+  display: none;
+}
+/* editing state */
+.app-navigation-entry--editing .app-navigation-entry-edit[data-v-018c4203] {
+  z-index: 250;
+  opacity: 1;
+}
+/* deleted state */
+.app-navigation-entry--deleted .app-navigation-entry-deleted[data-v-018c4203] {
+  z-index: 250;
+  transform: translateX(0);
+}
+/* pinned state */
+.app-navigation-entry--pinned[data-v-018c4203] {
+  order: 2;
+  margin-top: auto;
+}
+.app-navigation-entry--pinned ~ .app-navigation-entry--pinned[data-v-018c4203] {
+  margin-top: 0;
+}
+[data-themes*=highcontrast] .app-navigation-entry[data-v-018c4203]:active {
+  background-color: var(--color-primary-element-light-hover) !important;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-0e795eb7] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.app-navigation-input-confirm[data-v-0e795eb7] {
+  flex: 1 0 100%;
+  width: 100%;
+}
+.app-navigation-input-confirm form[data-v-0e795eb7] {
+  display: flex;
+}
+.app-navigation-input-confirm__input[data-v-0e795eb7] {
+  height: 34px;
+  flex: 1 1 100%;
+  font-size: 100% !important;
+  margin: 5px !important;
+  margin-left: -8px !important;
+  padding: 7px !important;
+}
+.app-navigation-input-confirm__input[data-v-0e795eb7]:active, .app-navigation-input-confirm__input[data-v-0e795eb7]:focus, .app-navigation-input-confirm__input[data-v-0e795eb7]:hover {
+  outline: none;
+  background-color: var(--color-main-background);
+  color: var(--color-main-text);
+  border-color: var(--color-primary-element);
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-810cb824] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+
+/* 'New' button */
+.app-navigation-new[data-v-810cb824] {
+  display: block;
+  padding: calc(var(--default-grid-baseline, 4px) * 2);
+}
+.app-navigation-new button[data-v-810cb824] {
+  width: 100%;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-fe96d301] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+/**
+ * SPDX-FileCopyrightText: 2023 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+.app-navigation-entry[data-v-fe96d301] {
+  position: relative;
+  display: flex;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+  box-sizing: border-box;
+  width: 100%;
+  min-height: var(--default-clickable-area);
+  transition: background-color var(--animation-quick) ease-in-out;
+  transition: background-color 200ms ease-in-out;
+  border-radius: var(--border-radius-element, var(--border-radius-pill));
+  /* hide deletion/collapse of subitems */
+}
+.app-navigation-entry-wrapper[data-v-fe96d301] {
+  position: relative;
+  display: flex;
+  flex-shrink: 0;
+  flex-wrap: wrap;
+  box-sizing: border-box;
+  width: 100%;
+}
+.app-navigation-entry-wrapper.app-navigation-entry--collapsible:not(.app-navigation-entry--opened) > ul[data-v-fe96d301] {
+  display: none;
+}
+.app-navigation-entry.active[data-v-fe96d301] {
+  background-color: var(--color-primary-element) !important;
+}
+.app-navigation-entry.active[data-v-fe96d301]:hover {
+  background-color: var(--color-primary-element-hover) !important;
+}
+.app-navigation-entry.active .app-navigation-entry-link[data-v-fe96d301], .app-navigation-entry.active .app-navigation-entry-button[data-v-fe96d301] {
+  color: var(--color-primary-element-text) !important;
+}
+.app-navigation-entry[data-v-fe96d301]:focus-within, .app-navigation-entry[data-v-fe96d301]:hover {
+  background-color: var(--color-background-hover);
+}
+.app-navigation-entry.active .app-navigation-entry__children[data-v-fe96d301], .app-navigation-entry:focus-within .app-navigation-entry__children[data-v-fe96d301], .app-navigation-entry:hover .app-navigation-entry__children[data-v-fe96d301] {
+  background-color: var(--color-main-background);
+}
+.app-navigation-entry.active .app-navigation-entry__utils .app-navigation-entry__actions[data-v-fe96d301], .app-navigation-entry.app-navigation-entry--deleted .app-navigation-entry__utils .app-navigation-entry__actions[data-v-fe96d301], .app-navigation-entry:focus .app-navigation-entry__utils .app-navigation-entry__actions[data-v-fe96d301], .app-navigation-entry:focus-within .app-navigation-entry__utils .app-navigation-entry__actions[data-v-fe96d301], .app-navigation-entry:hover .app-navigation-entry__utils .app-navigation-entry__actions[data-v-fe96d301] {
+  display: inline-block;
+}
+.app-navigation-entry.app-navigation-entry--deleted > ul[data-v-fe96d301] {
+  display: none;
+}
+.app-navigation-entry:not(.app-navigation-entry--editing) .app-navigation-entry-link[data-v-fe96d301], .app-navigation-entry:not(.app-navigation-entry--editing) .app-navigation-entry-button[data-v-fe96d301] {
+  padding-right: calc((var(--default-clickable-area) - 16px) / 2);
+}
+.app-navigation-entry .app-navigation-entry-link[data-v-fe96d301], .app-navigation-entry .app-navigation-entry-button[data-v-fe96d301] {
+  z-index: 100; /* above the bullet to allow click*/
+  display: flex;
+  overflow: hidden;
+  flex: 1 1 0;
+  box-sizing: border-box;
+  min-height: var(--default-clickable-area);
+  padding: 0;
+  white-space: nowrap;
+  color: var(--color-main-text);
+  background-repeat: no-repeat;
+  background-position: calc((var(--default-clickable-area) - 16px) / 2) center;
+  background-size: 16px 16px;
+  line-height: var(--default-clickable-area);
+}
+.app-navigation-entry .app-navigation-entry-link .app-navigation-entry-icon[data-v-fe96d301], .app-navigation-entry .app-navigation-entry-button .app-navigation-entry-icon[data-v-fe96d301] {
+  display: flex;
+  align-items: center;
+  flex: 0 0 var(--default-clickable-area);
+  justify-content: center;
+  width: var(--default-clickable-area);
+  height: var(--default-clickable-area);
+  background-size: 16px 16px;
+  background-repeat: no-repeat;
+  background-position: calc((var(--default-clickable-area) - 16px) / 2) center;
+}
+.app-navigation-entry .app-navigation-entry-link .app-navigation-entry__name[data-v-fe96d301], .app-navigation-entry .app-navigation-entry-button .app-navigation-entry__name[data-v-fe96d301] {
+  overflow: hidden;
+  max-width: 100%;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+.app-navigation-entry .app-navigation-entry-link .editingContainer[data-v-fe96d301], .app-navigation-entry .app-navigation-entry-button .editingContainer[data-v-fe96d301] {
+  width: calc(100% - var(--default-clickable-area));
+  margin: auto;
+}
+.app-navigation-entry .app-navigation-entry-link[data-v-fe96d301]:focus-visible, .app-navigation-entry .app-navigation-entry-button[data-v-fe96d301]:focus-visible {
+  box-shadow: 0 0 0 4px var(--color-main-background);
+  outline: 2px solid var(--color-main-text);
+  border-radius: var(--border-radius-element, var(--border-radius-pill));
+}
+/* Second level nesting for lists */
+.app-navigation-entry__children[data-v-fe96d301] {
+  position: relative;
+  display: flex;
+  flex: 0 1 auto;
+  flex-direction: column;
+  width: 100%;
+  gap: var(--default-grid-baseline, 4px);
+}
+.app-navigation-entry__children .app-navigation-entry[data-v-fe96d301] {
+  display: inline-flex;
+  flex-wrap: wrap;
+  padding-left: 16px;
+}
+/* Deleted entries */
+.app-navigation-entry__deleted[data-v-fe96d301] {
+  display: inline-flex;
+  flex: 1 1 0;
+  padding-left: calc(var(--default-clickable-area) - (var(--default-clickable-area) - 16px) / 2) !important;
+}
+.app-navigation-entry__deleted .app-navigation-entry__deleted-description[data-v-fe96d301] {
+  position: relative;
+  overflow: hidden;
+  flex: 1 1 0;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  line-height: var(--default-clickable-area);
+}
+/* counter and actions */
+.app-navigation-entry__utils[data-v-fe96d301] {
+  display: flex;
+  min-width: var(--default-clickable-area);
+  align-items: center;
+  flex: 0 1 auto;
+  justify-content: flex-end;
+  /* counter */
+  /* actions */
+}
+.app-navigation-entry__utils.app-navigation-entry__utils--display-actions .action-item.app-navigation-entry__actions[data-v-fe96d301] {
+  display: inline-block;
+}
+.app-navigation-entry__utils .app-navigation-entry__counter-wrapper[data-v-fe96d301] {
+  margin-right: calc(var(--default-grid-baseline) * 3);
+  display: flex;
+  align-items: center;
+  flex: 0 1 auto;
+}
+.app-navigation-entry__utils .action-item.app-navigation-entry__actions[data-v-fe96d301] {
+  display: none;
+}
+/* editing state */
+.app-navigation-entry--editing .app-navigation-entry-edit[data-v-fe96d301] {
+  z-index: 250;
+  opacity: 1;
+}
+/* deleted state */
+.app-navigation-entry--deleted .app-navigation-entry-deleted[data-v-fe96d301] {
+  z-index: 250;
+  transform: translateX(0);
+}
+/* pinned state */
+.app-navigation-entry--pinned[data-v-fe96d301] {
+  order: 2;
+  margin-top: auto;
+}
+.app-navigation-entry--pinned ~ .app-navigation-entry--pinned[data-v-fe96d301] {
+  margin-top: 0;
+}
+[data-themes*=highcontrast] .app-navigation-entry[data-v-fe96d301]:active {
+  background-color: var(--color-primary-element-light-hover) !important;
+}
+.app-navigation-new-item__name[data-v-fe96d301] {
+  overflow: hidden;
+  max-width: 100%;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  padding-left: 7px;
+  font-size: 14px;
+}
+.newItemContainer[data-v-fe96d301] {
+  width: calc(100% - var(--default-clickable-area));
+  margin: auto;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-70fd8f35] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.app-navigation-search[data-v-70fd8f35] {
+  display: flex;
+  gap: var(--app-navigation-padding);
+  padding: var(--app-navigation-padding);
+}
+.app-navigation-search--has-actions .app-navigation-search__input[data-v-70fd8f35] {
+  flex-grow: 1;
+  z-index: 3;
+}
+.app-navigation-search__actions[data-v-70fd8f35] {
+  display: flex;
+  gap: var(--default-grid-baseline);
+  margin-inline-start: 0;
+  max-width: calc(2 * var(--default-clickable-area) + var(--default-grid-baseline));
+  max-height: var(--default-clickable-area);
+  transition: margin-inline-start var(--animation-quick);
+}
+.app-navigation-search__actions--hidden[data-v-70fd8f35] {
+  margin-inline-start: calc(-1 * var(--default-clickable-area));
+}
+.app-navigation-search__input[data-v-70fd8f35] {
+  --input-border-radius: var(--border-radius-element, var(--border-radius-pill)) !important;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-981e215c] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+#app-settings[data-v-981e215c] {
+  margin-top: auto;
+  padding: 3px;
+}
+#app-settings__header[data-v-981e215c] {
+  box-sizing: border-box;
+  margin: 0 3px 3px 3px;
+}
+#app-settings__header .settings-button[data-v-981e215c] {
+  display: flex;
+  flex: 1 1 0;
+  height: var(--default-clickable-area);
+  width: 100%;
+  padding: 0;
+  margin: 0;
+  background-color: transparent;
+  box-shadow: none;
+  border: 0;
+  border-radius: var(--body-container-radius);
+  text-align: left;
+  font-weight: normal;
+  font-size: 100%;
+  color: var(--color-main-text);
+  padding-right: 14px;
+  line-height: var(--default-clickable-area);
+}
+#app-settings__header .settings-button[data-v-981e215c]:hover, #app-settings__header .settings-button[data-v-981e215c]:focus {
+  background-color: var(--color-background-hover);
+}
+#app-settings__header .settings-button__icon[data-v-981e215c] {
+  width: var(--default-clickable-area);
+  height: var(--default-clickable-area);
+  min-width: var(--default-clickable-area);
+}
+#app-settings__header .settings-button__label[data-v-981e215c] {
+  overflow: hidden;
+  max-width: 100%;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+#app-settings__content[data-v-981e215c] {
+  display: block;
+  padding: 10px;
+  /* prevent scrolled contents from stopping too early */
+  margin-bottom: -3px;
+  /* restrict height of settings and make scrollable */
+  max-height: 300px;
+  overflow-y: auto;
+  box-sizing: border-box;
+}
+.slide-up-leave-active[data-v-981e215c],
+.slide-up-enter-active[data-v-981e215c] {
+  transition-duration: var(--animation-slow);
+  transition-property: max-height, padding;
+  overflow-y: hidden !important;
+}
+.slide-up-enter[data-v-981e215c],
+.slide-up-leave-to[data-v-981e215c] {
+  max-height: 0 !important;
+  padding: 0 10px !important;
+}
+.app-navigation-spacer[data-v-b699c557] {
+	flex-shrink: 0;
+	height: 22px;
+}
+
+/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-0674bd2e] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+[data-v-0674bd2e] .app-settings__navigation {
+  min-width: 200px;
+  margin-right: calc(4 * var(--default-grid-baseline));
+  overflow-x: hidden;
+  overflow-y: auto;
+  position: relative;
+}
+[data-v-0674bd2e] .app-settings__content {
+  box-sizing: border-box;
+  padding-inline: calc(4 * var(--default-grid-baseline));
+}
+.navigation-list[data-v-0674bd2e] {
+  height: 100%;
+  box-sizing: border-box;
+  overflow-y: auto;
+  padding: calc(3 * var(--default-grid-baseline));
+}
+.navigation-list__link[data-v-0674bd2e] {
+  display: flex;
+  align-content: center;
+  font-size: 16px;
+  height: var(--default-clickable-area);
+  margin: 4px 0;
+  line-height: var(--default-clickable-area);
+  border-radius: var(--border-radius-element, var(--border-radius-pill));
+  font-weight: bold;
+  padding: 0 calc(4 * var(--default-grid-baseline));
+  cursor: pointer;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  background-color: transparent;
+  border: none;
+}
+.navigation-list__link[data-v-0674bd2e]:hover, .navigation-list__link[data-v-0674bd2e]:focus {
+  background-color: var(--color-background-hover);
+}
+.navigation-list__link--active[data-v-0674bd2e] {
+  background-color: var(--color-primary-element-light) !important;
+}
+.navigation-list__link--icon[data-v-0674bd2e] {
+  padding-inline-start: calc(2 * var(--default-grid-baseline));
+  gap: var(--default-grid-baseline);
+}
+.navigation-list__link-icon[data-v-0674bd2e] {
+  display: flex;
+  justify-content: center;
+  align-content: center;
+  width: calc(var(--default-clickable-area) - 2 * var(--default-grid-baseline));
+  max-width: calc(var(--default-clickable-area) - 2 * var(--default-grid-baseline));
+}
+@media only screen and (max-width: 512px) {
+.app-settings[data-v-0674bd2e] .dialog__name {
+    padding-inline-start: 16px;
+}
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-e970c9f7] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.app-settings-section[data-v-e970c9f7] {
+  margin-bottom: 80px;
+}
+.app-settings-section__name[data-v-e970c9f7] {
+  font-size: 1.6em;
+  margin: 0;
+  padding: 20px 0;
+  font-weight: bold;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-77326a9c] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.app-sidebar-tabs[data-v-77326a9c] {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  flex: 1 1 100%;
+}
+.app-sidebar-tabs__nav[data-v-77326a9c] {
+  display: flex;
+  justify-content: stretch;
+  margin: 10px 8px 0 8px;
+  border-bottom: 1px solid var(--color-border);
+}
+.app-sidebar-tabs__nav[data-v-77326a9c] .checkbox-radio-switch--button-variant {
+  border: unset !important;
+  border-radius: 0 !important;
+}
+.app-sidebar-tabs__nav[data-v-77326a9c] .checkbox-radio-switch--button-variant .checkbox-content {
+  padding: var(--default-grid-baseline);
+  border-radius: var(--default-grid-baseline) var(--default-grid-baseline) 0 0 !important;
+  margin: 0 !important;
+  border-bottom: var(--default-grid-baseline) solid transparent !important;
+}
+.app-sidebar-tabs__nav[data-v-77326a9c] .checkbox-radio-switch--button-variant .checkbox-content .checkbox-content__icon--checked > * {
+  color: var(--color-main-text) !important;
+}
+.app-sidebar-tabs__nav[data-v-77326a9c] .checkbox-radio-switch--button-variant.checkbox-radio-switch--checked .checkbox-radio-switch__content {
+  background: transparent !important;
+  color: var(--color-main-text) !important;
+  border-bottom: var(--default-grid-baseline) solid var(--color-primary-element) !important;
+}
+.app-sidebar-tabs__tab[data-v-77326a9c] {
+  flex: 1 1;
+}
+.app-sidebar-tabs__tab.active[data-v-77326a9c] {
+  color: var(--color-primary-element);
+}
+.app-sidebar-tabs__tab-caption[data-v-77326a9c] {
+  flex: 0 1 100%;
+  width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  text-align: center;
+}
+.app-sidebar-tabs__tab-icon[data-v-77326a9c] {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-size: 20px;
+}
+.app-sidebar-tabs__tab[data-v-77326a9c] .checkbox-radio-switch__content {
+  max-width: unset;
+}
+.app-sidebar-tabs__content[data-v-77326a9c] {
+  position: relative;
+  min-height: 256px;
+  height: 100%;
+}
+.app-sidebar-tabs__content--multiple[data-v-77326a9c] > :not(section) {
+  display: none;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+@property --app-sidebar-offset {
+  syntax: "<length>";
+  initial-value: 0;
+  inherits: true;
+}
+.content {
+  --app-sidebar-padding: calc(var(--default-grid-baseline, 4px) * 2);
+  --app-sidebar-offset: 0;
+  transition: --app-sidebar-offset 0ms !important;
+}
+.content:has(.app-sidebar.slide-right-enter-active),
+.content:has(.app-sidebar.slide-right-leave-active) {
+  transition: --app-sidebar-offset var(--animation-quick);
+}
+.content:has(.app-sidebar__toggle) {
+  --app-sidebar-offset: calc(var(--app-sidebar-padding) + var(--default-clickable-area));
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-2d142c0a] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+
+/*
+	Sidebar: to be used within #content
+	app-content will be shrinked properly
+*/
+.app-sidebar[data-v-2d142c0a] {
+  --app-sidebar-width: clamp(300px, 27vw, 500px);
+  width: var(--app-sidebar-width);
+  z-index: 1500;
+  top: 0;
+  right: 0;
+  display: flex;
+  overflow-x: hidden;
+  overflow-y: auto;
+  flex-direction: column;
+  flex-shrink: 0;
+  height: 100%;
+  border-left: 1px solid var(--color-border);
+  background: var(--color-main-background);
+  position: relative;
+}
+.app-sidebar__toggle[data-v-2d142c0a] {
+  position: absolute !important;
+  inset-block-start: var(--app-sidebar-padding);
+  inset-inline-end: var(--app-sidebar-padding);
+  z-index: 1001;
+}
+.app-sidebar .app-sidebar-header > .app-sidebar__close[data-v-2d142c0a] {
+  position: absolute;
+  z-index: 100;
+  top: calc(var(--default-grid-baseline, 4px) * 2);
+  right: calc(var(--default-grid-baseline, 4px) * 2);
+  width: var(--default-clickable-area);
+  height: var(--default-clickable-area);
+  opacity: 0.7;
+  border-radius: calc(var(--default-clickable-area) / 2);
+}
+.app-sidebar .app-sidebar-header > .app-sidebar__close[data-v-2d142c0a]:hover, .app-sidebar .app-sidebar-header > .app-sidebar__close[data-v-2d142c0a]:active, .app-sidebar .app-sidebar-header > .app-sidebar__close[data-v-2d142c0a]:focus {
+  opacity: 1;
+  background-color: rgba(127, 127, 127, 0.25);
+}
+.app-sidebar .app-sidebar-header--compact.app-sidebar-header--with-figure .app-sidebar-header__info[data-v-2d142c0a] {
+  flex-direction: row;
+}
+.app-sidebar .app-sidebar-header--compact.app-sidebar-header--with-figure .app-sidebar-header__info .app-sidebar-header__figure[data-v-2d142c0a] {
+  --figure-size: calc($desc-height + var(--app-sidebar-padding));
+  z-index: 2;
+  width: var(--figure-size);
+  height: var(--figure-size);
+  margin: calc(var(--app-sidebar-padding) / 2);
+  border-radius: 3px;
+  flex: 0 0 auto;
+}
+.app-sidebar .app-sidebar-header--compact.app-sidebar-header--with-figure .app-sidebar-header__info .app-sidebar-header__desc[data-v-2d142c0a] {
+  padding-left: 0;
+  flex: 1 1 auto;
+  min-width: 0;
+  padding-right: calc(2 * var(--default-clickable-area) + var(--default-grid-baseline, 4px) * 2);
+  padding-top: var(--app-sidebar-padding);
+}
+.app-sidebar .app-sidebar-header--compact.app-sidebar-header--with-figure .app-sidebar-header__info .app-sidebar-header__desc.app-sidebar-header__desc--without-actions[data-v-2d142c0a] {
+  padding-right: calc(var(--default-clickable-area) + var(--default-grid-baseline, 4px) * 2);
+}
+.app-sidebar .app-sidebar-header--compact.app-sidebar-header--with-figure .app-sidebar-header__info .app-sidebar-header__desc .app-sidebar-header__tertiary-actions[data-v-2d142c0a] {
+  z-index: 3;
+  position: absolute;
+  top: calc(var(--app-sidebar-padding) / 2);
+  left: calc(-1 * var(--default-clickable-area));
+  gap: 0;
+}
+.app-sidebar .app-sidebar-header--compact.app-sidebar-header--with-figure .app-sidebar-header__info .app-sidebar-header__desc .app-sidebar-header__menu[data-v-2d142c0a] {
+  top: calc(var(--default-grid-baseline, 4px) * 2);
+  right: calc(var(--default-clickable-area) + var(--default-grid-baseline, 4px) * 2);
+  position: absolute;
+}
+.app-sidebar .app-sidebar-header:not(.app-sidebar-header--with-figure) .app-sidebar-header__menu[data-v-2d142c0a] {
+  position: absolute;
+  top: calc(var(--default-grid-baseline, 4px) * 2);
+  right: calc(var(--default-grid-baseline, 4px) * 2 + var(--default-clickable-area));
+}
+.app-sidebar .app-sidebar-header:not(.app-sidebar-header--with-figure) .app-sidebar-header__desc[data-v-2d142c0a] {
+  padding-right: calc(var(--default-clickable-area) * 2 + var(--default-grid-baseline, 4px) * 2);
+}
+.app-sidebar .app-sidebar-header:not(.app-sidebar-header--with-figure) .app-sidebar-header__desc.app-sidebar-header__desc--without-actions[data-v-2d142c0a] {
+  padding-right: calc(var(--default-clickable-area) + var(--default-grid-baseline, 4px) * 2);
+}
+.app-sidebar .app-sidebar-header .app-sidebar-header__info[data-v-2d142c0a] {
+  display: flex;
+  flex-direction: column;
+}
+.app-sidebar .app-sidebar-header__figure[data-v-2d142c0a] {
+  width: 100%;
+  height: 250px;
+  max-height: 250px;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+}
+.app-sidebar .app-sidebar-header__figure--with-action[data-v-2d142c0a] {
+  cursor: pointer;
+}
+.app-sidebar .app-sidebar-header__desc[data-v-2d142c0a] {
+  position: relative;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  padding-inline: var(--app-sidebar-padding);
+  padding-block: calc(var(--default-grid-baseline, 4px) * 2) calc(var(--app-sidebar-padding) / 2);
+  gap: 0 4px;
+}
+.app-sidebar .app-sidebar-header__desc--with-tertiary-action[data-v-2d142c0a] {
+  padding-left: 6px;
+}
+.app-sidebar .app-sidebar-header__desc--editable .app-sidebar-header__mainname-form[data-v-2d142c0a], .app-sidebar .app-sidebar-header__desc--with-subname--editable .app-sidebar-header__mainname-form[data-v-2d142c0a] {
+  margin-top: -2px;
+  margin-bottom: -2px;
+}
+.app-sidebar .app-sidebar-header__desc--with-subname--editable .app-sidebar-header__subname[data-v-2d142c0a] {
+  margin-top: -2px;
+}
+.app-sidebar .app-sidebar-header__desc .app-sidebar-header__tertiary-actions[data-v-2d142c0a] {
+  display: flex;
+  height: var(--default-clickable-area);
+  width: var(--default-clickable-area);
+  justify-content: center;
+  flex: 0 0 auto;
+}
+.app-sidebar .app-sidebar-header__desc .app-sidebar-header__tertiary-actions .app-sidebar-header__star[data-v-2d142c0a] {
+  box-shadow: none;
+}
+.app-sidebar .app-sidebar-header__desc .app-sidebar-header__tertiary-actions .app-sidebar-header__star[data-v-2d142c0a]:not([aria-pressed=true]):hover {
+  box-shadow: none;
+  background-color: var(--color-background-hover);
+}
+.app-sidebar .app-sidebar-header__desc .app-sidebar-header__name-container[data-v-2d142c0a] {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-width: 0;
+}
+.app-sidebar .app-sidebar-header__desc .app-sidebar-header__name-container .app-sidebar-header__mainname-container[data-v-2d142c0a] {
+  display: flex;
+  align-items: center;
+  min-height: var(--default-clickable-area);
+}
+.app-sidebar .app-sidebar-header__desc .app-sidebar-header__name-container .app-sidebar-header__mainname-container .app-sidebar-header__mainname[data-v-2d142c0a] {
+  padding: 0;
+  min-height: 30px;
+  font-size: 20px;
+  line-height: 30px;
+}
+.app-sidebar .app-sidebar-header__desc .app-sidebar-header__name-container .app-sidebar-header__mainname-container .app-sidebar-header__mainname[data-v-2d142c0a] .linkified {
+  cursor: pointer;
+  text-decoration: underline;
+  margin: 0;
+}
+.app-sidebar .app-sidebar-header__desc .app-sidebar-header__name-container .app-sidebar-header__mainname-container .app-sidebar-header__mainname-form[data-v-2d142c0a] {
+  display: flex;
+  flex: 1 1 auto;
+  align-items: center;
+}
+.app-sidebar .app-sidebar-header__desc .app-sidebar-header__name-container .app-sidebar-header__mainname-container .app-sidebar-header__mainname-form input.app-sidebar-header__mainname-input[data-v-2d142c0a] {
+  flex: 1 1 auto;
+  margin: 0;
+  padding: 7px;
+  font-size: 20px;
+  font-weight: bold;
+}
+.app-sidebar .app-sidebar-header__desc .app-sidebar-header__name-container .app-sidebar-header__mainname-container .app-sidebar-header__menu[data-v-2d142c0a] {
+  margin-left: 5px;
+}
+.app-sidebar .app-sidebar-header__desc .app-sidebar-header__name-container .app-sidebar-header__mainname[data-v-2d142c0a],
+.app-sidebar .app-sidebar-header__desc .app-sidebar-header__name-container .app-sidebar-header__subname[data-v-2d142c0a] {
+  overflow: hidden;
+  width: 100%;
+  margin: 0;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+.app-sidebar .app-sidebar-header__desc .app-sidebar-header__name-container .app-sidebar-header__subname[data-v-2d142c0a] {
+  color: var(--color-text-maxcontrast);
+  font-size: var(--default-font-size);
+  padding: 0;
+}
+.app-sidebar .app-sidebar-header__desc .app-sidebar-header__name-container .app-sidebar-header__subname *[data-v-2d142c0a] {
+  vertical-align: text-bottom;
+}
+.app-sidebar .app-sidebar-header__description[data-v-2d142c0a] {
+  display: flex;
+  align-items: center;
+  margin: 0 10px;
+}
+@media only screen and (max-width: 512px) {
+.app-sidebar[data-v-2d142c0a] {
+    position: absolute;
+    --app-sidebar-width: 100vw;
+}
+}
+.slide-right-leave-active[data-v-2d142c0a],
+.slide-right-enter-active[data-v-2d142c0a] {
+  transition-duration: var(--animation-quick);
+  transition-property: margin-right;
+}
+.slide-right-enter-to[data-v-2d142c0a],
+.slide-right-leave[data-v-2d142c0a] {
+  margin-right: 0;
+}
+.slide-right-enter[data-v-2d142c0a],
+.slide-right-leave-to[data-v-2d142c0a] {
+  margin-right: calc(-1 * var(--app-sidebar-width));
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.app-sidebar-header__description button, .app-sidebar-header__description .button,
+.app-sidebar-header__description input[type=button],
+.app-sidebar-header__description input[type=submit],
+.app-sidebar-header__description input[type=reset] {
+  padding: 6px 22px;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-e75842d8] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.checkbox-content[data-v-e75842d8] {
+  display: flex;
+  align-items: center;
+  flex-direction: row;
+  gap: var(--default-grid-baseline);
+  user-select: none;
+  min-height: var(--default-clickable-area);
+  border-radius: var(--checkbox-radio-switch--border-radius);
+  padding: var(--default-grid-baseline) calc((var(--default-clickable-area) - var(--icon-height)) / 2);
+  width: 100%;
+  max-width: fit-content;
+}
+.checkbox-content__text[data-v-e75842d8] {
+  flex: 1 0;
+}
+.checkbox-content__text[data-v-e75842d8]:empty {
+  display: none;
+}
+.checkbox-content__icon > *[data-v-e75842d8] {
+  width: var(--icon-size);
+  height: var(--icon-size);
+}
+.checkbox-content--button-variant .checkbox-content__icon:not(.checkbox-content__icon--checked) > *[data-v-e75842d8] {
+  color: var(--color-primary-element);
+}
+.checkbox-content--button-variant .checkbox-content__icon--checked > *[data-v-e75842d8] {
+  color: var(--color-primary-element-text);
+}
+.checkbox-content--has-text[data-v-e75842d8] {
+  padding-right: calc((var(--default-clickable-area) - 16px) / 2);
+}
+.checkbox-content:not(.checkbox-content--button-variant) .checkbox-content__icon > *[data-v-e75842d8] {
+  color: var(--color-primary-element);
+}
+.checkbox-content[data-v-e75842d8], .checkbox-content *[data-v-e75842d8] {
+  cursor: pointer;
+  flex-shrink: 0;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-feaabebe] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.checkbox-radio-switch[data-v-feaabebe] {
+  display: flex;
+  align-items: center;
+  color: var(--color-main-text);
+  background-color: transparent;
+  font-size: var(--default-font-size);
+  line-height: var(--default-line-height);
+  padding: 0;
+  position: relative;
+  --checkbox-radio-switch--border-radius: var(--border-radius-element, calc(var(--default-clickable-area) / 2));
+  --checkbox-radio-switch--border-radius-outer: calc(var(--checkbox-radio-switch--border-radius) + 2px);
+  /* Special rules for vertical button groups */
+  /* Special rules for horizontal button groups */
+}
+.checkbox-radio-switch__input[data-v-feaabebe] {
+  position: absolute;
+  z-index: -1;
+  opacity: 0 !important;
+  width: var(--icon-size);
+  height: var(--icon-size);
+  margin: 4px calc((var(--default-clickable-area) - 16px) / 2);
+}
+.checkbox-radio-switch__input:focus-visible + .checkbox-radio-switch__content[data-v-feaabebe], .checkbox-radio-switch__input[data-v-feaabebe]:focus-visible {
+  outline: 2px solid var(--color-main-text);
+  border-color: var(--color-main-background);
+  outline-offset: -2px;
+}
+.checkbox-radio-switch--disabled .checkbox-radio-switch__content[data-v-feaabebe] {
+  opacity: 0.5;
+}
+.checkbox-radio-switch--disabled .checkbox-radio-switch__content[data-v-feaabebe] .checkbox-radio-switch__icon > * {
+  color: var(--color-main-text);
+}
+.checkbox-radio-switch:not(.checkbox-radio-switch--disabled, .checkbox-radio-switch--checked):focus-within .checkbox-radio-switch__content[data-v-feaabebe], .checkbox-radio-switch:not(.checkbox-radio-switch--disabled, .checkbox-radio-switch--checked) .checkbox-radio-switch__content[data-v-feaabebe]:hover {
+  background-color: var(--color-background-hover);
+}
+.checkbox-radio-switch--checked:not(.checkbox-radio-switch--disabled):focus-within .checkbox-radio-switch__content[data-v-feaabebe], .checkbox-radio-switch--checked:not(.checkbox-radio-switch--disabled) .checkbox-radio-switch__content[data-v-feaabebe]:hover {
+  background-color: var(--color-primary-element-hover);
+}
+.checkbox-radio-switch--checked:not(.checkbox-radio-switch--button-variant):not(.checkbox-radio-switch--disabled):focus-within .checkbox-radio-switch__content[data-v-feaabebe], .checkbox-radio-switch--checked:not(.checkbox-radio-switch--button-variant):not(.checkbox-radio-switch--disabled) .checkbox-radio-switch__content[data-v-feaabebe]:hover {
+  background-color: var(--color-primary-element-light-hover);
+}
+.checkbox-radio-switch-switch[data-v-feaabebe]:not(.checkbox-radio-switch--checked) .checkbox-radio-switch__icon > * {
+  color: var(--color-text-maxcontrast);
+}
+.checkbox-radio-switch-switch.checkbox-radio-switch--disabled.checkbox-radio-switch--checked[data-v-feaabebe] .checkbox-radio-switch__icon > * {
+  color: var(--color-primary-element-light);
+}
+.checkbox-radio-switch--button-variant.checkbox-radio-switch[data-v-feaabebe] {
+  background-color: var(--color-main-background);
+  border: 2px solid var(--color-border-maxcontrast);
+  overflow: hidden;
+}
+.checkbox-radio-switch--button-variant.checkbox-radio-switch--checked[data-v-feaabebe] {
+  font-weight: bold;
+}
+.checkbox-radio-switch--button-variant.checkbox-radio-switch--checked .checkbox-radio-switch__content[data-v-feaabebe] {
+  background-color: var(--color-primary-element);
+  color: var(--color-primary-element-text);
+}
+.checkbox-radio-switch--button-variant[data-v-feaabebe] .checkbox-radio-switch__text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 100%;
+}
+.checkbox-radio-switch--button-variant[data-v-feaabebe]:not(.checkbox-radio-switch--checked) .checkbox-radio-switch__icon > * {
+  color: var(--color-main-text);
+}
+.checkbox-radio-switch--button-variant[data-v-feaabebe] .checkbox-radio-switch__icon:empty {
+  display: none;
+}
+.checkbox-radio-switch--button-variant[data-v-feaabebe]:not(.checkbox-radio-switch--button-variant-v-grouped):not(.checkbox-radio-switch--button-variant-h-grouped), .checkbox-radio-switch--button-variant .checkbox-radio-switch__content[data-v-feaabebe] {
+  border-radius: var(--checkbox-radio-switch--border-radius);
+}
+.checkbox-radio-switch--button-variant-v-grouped .checkbox-radio-switch__content[data-v-feaabebe] {
+  flex-basis: 100%;
+  max-width: unset;
+}
+.checkbox-radio-switch--button-variant-v-grouped[data-v-feaabebe]:first-of-type {
+  border-top-left-radius: var(--checkbox-radio-switch--border-radius-outer);
+  border-top-right-radius: var(--checkbox-radio-switch--border-radius-outer);
+}
+.checkbox-radio-switch--button-variant-v-grouped[data-v-feaabebe]:last-of-type {
+  border-bottom-left-radius: var(--checkbox-radio-switch--border-radius-outer);
+  border-bottom-right-radius: var(--checkbox-radio-switch--border-radius-outer);
+}
+.checkbox-radio-switch--button-variant-v-grouped[data-v-feaabebe]:not(:last-of-type) {
+  border-bottom: 0 !important;
+}
+.checkbox-radio-switch--button-variant-v-grouped:not(:last-of-type) .checkbox-radio-switch__content[data-v-feaabebe] {
+  margin-bottom: 2px;
+}
+.checkbox-radio-switch--button-variant-v-grouped[data-v-feaabebe]:not(:first-of-type) {
+  border-top: 0 !important;
+}
+.checkbox-radio-switch--button-variant-h-grouped[data-v-feaabebe]:first-of-type {
+  border-top-left-radius: var(--checkbox-radio-switch--border-radius-outer);
+  border-bottom-left-radius: var(--checkbox-radio-switch--border-radius-outer);
+}
+.checkbox-radio-switch--button-variant-h-grouped[data-v-feaabebe]:last-of-type {
+  border-top-right-radius: var(--checkbox-radio-switch--border-radius-outer);
+  border-bottom-right-radius: var(--checkbox-radio-switch--border-radius-outer);
+}
+.checkbox-radio-switch--button-variant-h-grouped[data-v-feaabebe]:not(:last-of-type) {
+  border-right: 0 !important;
+}
+.checkbox-radio-switch--button-variant-h-grouped:not(:last-of-type) .checkbox-radio-switch__content[data-v-feaabebe] {
+  margin-right: 2px;
+}
+.checkbox-radio-switch--button-variant-h-grouped[data-v-feaabebe]:not(:first-of-type) {
+  border-left: 0 !important;
+}
+.checkbox-radio-switch--button-variant-h-grouped[data-v-feaabebe] .checkbox-radio-switch__text {
+  text-align: center;
+  display: flex;
+  align-items: center;
+}
+.checkbox-radio-switch--button-variant-h-grouped .checkbox-radio-switch__content[data-v-feaabebe] {
+  flex-direction: column;
+  justify-content: center;
+  width: 100%;
+  margin: 0;
+  gap: 0;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-fede0c71] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.empty-content[data-v-fede0c71] {
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  justify-content: center;
+  /* In case of using in a flex container - flex in advance */
+  flex-grow: 1;
+}
+.modal-wrapper .empty-content[data-v-fede0c71] {
+  margin-top: 5vh;
+  margin-bottom: 5vh;
+}
+.empty-content__icon[data-v-fede0c71] {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 64px;
+  height: 64px;
+  margin: 0 auto 15px;
+  opacity: 0.4;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 64px;
+}
+.empty-content__icon[data-v-fede0c71] svg {
+  width: 64px !important;
+  height: 64px !important;
+  max-width: 64px !important;
+  max-height: 64px !important;
+}
+.empty-content__name[data-v-fede0c71] {
+  margin-bottom: 10px;
+  text-align: center;
+  font-weight: bold;
+  font-size: 20px;
+  line-height: 30px;
+}
+.empty-content__description[data-v-fede0c71] {
+  color: var(--color-text-maxcontrast);
+}
+.empty-content__action[data-v-fede0c71] {
+  margin-top: 8px;
+}
+.modal-wrapper .empty-content__action[data-v-fede0c71] {
+  margin-top: 20px;
+  display: flex;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-095ea4ce] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.app-sidebar__tab[data-v-095ea4ce] {
+  display: none;
+  padding: 10px;
+  min-height: 100%;
+  max-height: 100%;
+  height: 100%;
+  overflow: auto;
+}
+.app-sidebar__tab[data-v-095ea4ce]:focus {
+  border-color: var(--color-primary-element);
+  box-shadow: 0 0 0.2em var(--color-primary-element);
+  outline: 0;
+}
+.app-sidebar__tab--active[data-v-095ea4ce] {
+  display: block;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-cfe13af3] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.vue-crumb[data-v-cfe13af3] {
+  background-image: none;
+  display: inline-flex;
+  height: var(--default-clickable-area);
+  padding: 0;
+}
+.vue-crumb[data-v-cfe13af3]:last-child {
+  min-width: 0;
+}
+.vue-crumb:last-child .vue-crumb__separator[data-v-cfe13af3] {
+  display: none;
+}
+.vue-crumb--hidden[data-v-cfe13af3] {
+  display: none;
+}
+.vue-crumb__separator[data-v-cfe13af3] {
+  padding: 0;
+  color: var(--color-text-maxcontrast);
+}
+.vue-crumb.vue-crumb--hovered[data-v-cfe13af3] .button-vue {
+  background-color: var(--color-background-dark);
+  color: var(--color-main-text);
+}
+.vue-crumb[data-v-cfe13af3]:not(:last-child)  .button-vue {
+  color: var(--color-text-maxcontrast);
+}
+.vue-crumb[data-v-cfe13af3]:not(:last-child)  .button-vue:hover, .vue-crumb[data-v-cfe13af3]:not(:last-child)  .button-vue:focus {
+  background-color: var(--color-background-dark);
+  color: var(--color-main-text);
+}
+.vue-crumb[data-v-cfe13af3]:not(:last-child)  .button-vue__text {
+  font-weight: normal;
+}
+.vue-crumb[data-v-cfe13af3] .button-vue__text {
+  margin: 0;
+}
+.vue-crumb[data-v-cfe13af3]:not(.dropdown) .action-item {
+  max-width: 100%;
+}
+.vue-crumb[data-v-cfe13af3]:not(.dropdown) .action-item .button-vue {
+  padding: 0 4px 0 16px;
+  max-width: 100%;
+}
+.vue-crumb[data-v-cfe13af3]:not(.dropdown) .action-item .button-vue__wrapper {
+  flex-direction: row-reverse;
+}
+.vue-crumb[data-v-cfe13af3]:not(.dropdown) .action-item.action-item--open .action-item__menutoggle {
+  background-color: var(--color-background-dark);
+  color: var(--color-main-text);
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-629bf30f] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.breadcrumb[data-v-629bf30f] {
+  width: 100%;
+  flex-grow: 1;
+  display: inline-flex;
+  align-items: center;
+}
+.breadcrumb--collapsed[data-v-629bf30f] .vue-crumb:last-child {
+  min-width: 100px;
+}
+.breadcrumb nav[data-v-629bf30f] {
+  flex-shrink: 1;
+  min-width: 0;
+}
+.breadcrumb .breadcrumb__crumbs[data-v-629bf30f] {
+  max-width: 100%;
+}
+.breadcrumb .breadcrumb__crumbs[data-v-629bf30f], .breadcrumb .breadcrumb__actions[data-v-629bf30f] {
+  display: inline-flex;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-878b819f] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.fade-enter-active[data-v-878b819f], .fade-leave-active[data-v-878b819f] {
+  transition: opacity 0.3s ease;
+}
+.fade-enter[data-v-878b819f], .fade-leave-to[data-v-878b819f] {
+  opacity: 0;
+}
+.linked-icons[data-v-878b819f] {
+  display: flex;
+}
+.linked-icons img[data-v-878b819f] {
+  padding: 12px;
+  height: 44px;
+  display: block;
+  background-repeat: no-repeat;
+  background-position: center;
+  opacity: 0.7;
+}
+.linked-icons img[data-v-878b819f]:hover {
+  opacity: 1;
+}
+.popovermenu[data-v-878b819f] {
+  display: none;
+}
+.popovermenu.open[data-v-878b819f] {
+  display: block;
+}
+li.collection-list-item[data-v-878b819f] {
+  flex-wrap: wrap;
+  height: auto;
+  cursor: pointer;
+  margin-bottom: 0 !important;
+}
+li.collection-list-item .collection-avatar[data-v-878b819f] {
+  margin-top: 0;
+}
+li.collection-list-item form[data-v-878b819f], li.collection-list-item .collection-item-name[data-v-878b819f] {
+  flex-basis: 10%;
+  flex-grow: 1;
+  display: flex;
+}
+li.collection-list-item .collection-item-name[data-v-878b819f] {
+  padding: 12px 9px;
+}
+li.collection-list-item input[data-v-878b819f] {
+  margin-top: 4px;
+  border-color: var(--color-border-maxcontrast);
+}
+li.collection-list-item input[type=text][data-v-878b819f] {
+  flex-grow: 1;
+}
+li.collection-list-item .error[data-v-878b819f] {
+  flex-basis: 100%;
+  width: 100%;
+}
+li.collection-list-item .resource-list-details[data-v-878b819f] {
+  flex-basis: 100%;
+  width: 100%;
+}
+li.collection-list-item .resource-list-details li[data-v-878b819f] {
+  display: flex;
+  margin-left: 44px;
+  border-radius: 3px;
+  cursor: pointer;
+}
+li.collection-list-item .resource-list-details li[data-v-878b819f]:hover {
+  background-color: var(--color-background-dark);
+}
+li.collection-list-item .resource-list-details li a[data-v-878b819f] {
+  flex-grow: 1;
+  padding: 3px;
+  max-width: calc(100% - 30px);
+  display: flex;
+}
+li.collection-list-item .resource-list-details span[data-v-878b819f] {
+  display: inline-block;
+  vertical-align: top;
+  margin-right: 10px;
+}
+li.collection-list-item .resource-list-details span.resource-name[data-v-878b819f] {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  position: relative;
+  vertical-align: top;
+  white-space: nowrap;
+  flex-grow: 1;
+  padding: 4px;
+}
+li.collection-list-item .resource-list-details img[data-v-878b819f] {
+  width: 24px;
+  height: 24px;
+}
+li.collection-list-item .resource-list-details .icon-close[data-v-878b819f] {
+  opacity: 0.7;
+}
+li.collection-list-item .resource-list-details .icon-close[data-v-878b819f]:hover, li.collection-list-item .resource-list-details .icon-close[data-v-878b819f]:focus {
+  opacity: 1;
+}
+.should-shake[data-v-878b819f] {
+  animation: shake-878b819f 0.6s 1 linear;
+}
+@keyframes shake-878b819f {
+0% {
+    transform: translate(15px);
+}
+20% {
+    transform: translate(-15px);
+}
+40% {
+    transform: translate(7px);
+}
+60% {
+    transform: translate(-7px);
+}
+80% {
+    transform: translate(3px);
+}
+100% {
+    transform: translate(0px);
+}
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-efe8beb8] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.collection-list *[data-v-efe8beb8] {
+  box-sizing: border-box;
+}
+.collection-list > li[data-v-efe8beb8] {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.collection-list > li > .avatar[data-v-efe8beb8] {
+  margin-top: 0;
+}
+#collection-select-container[data-v-efe8beb8] {
+  display: flex;
+  flex-direction: column;
+}
+.v-select span.avatar[data-v-efe8beb8] {
+  display: block;
+  padding: 16px;
+  opacity: 0.7;
+  background-repeat: no-repeat;
+  background-position: center;
+}
+.v-select span.avatar[data-v-efe8beb8]:hover {
+  opacity: 1;
+}
+p.hint[data-v-efe8beb8] {
+  z-index: 1;
+  margin-top: -16px;
+  padding: 8px 8px;
+  color: var(--color-text-maxcontrast);
+  line-height: normal;
+}
+div.avatar[data-v-efe8beb8] {
+  width: 32px;
+  height: 32px;
+  margin: 0;
+  padding: 8px;
+  background-color: var(--color-background-dark);
+  margin-top: 30px;
+}
+
+/** TODO provide white icon in core */
+.icon-projects[data-v-efe8beb8] {
+  display: block;
+  padding: 8px;
+  background-repeat: no-repeat;
+  background-position: center;
+}
+.option__wrapper[data-v-efe8beb8] {
+  display: flex;
+}
+.option__wrapper .avatar[data-v-efe8beb8] {
+  display: block;
+  width: 32px;
+  height: 32px;
+  background-color: var(--color-background-darker) !important;
+}
+.option__wrapper .option__title[data-v-efe8beb8] {
+  padding: 4px;
+}
+.fade-enter-active[data-v-efe8beb8], .fade-leave-active[data-v-efe8beb8] {
+  transition: opacity 0.5s;
+}
+.fade-enter[data-v-efe8beb8], .fade-leave-to[data-v-efe8beb8] {
+  opacity: 0;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-cc496c1d] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.color-picker[data-v-cc496c1d] {
+  display: flex;
+  overflow: hidden;
+  align-content: flex-end;
+  flex-direction: column;
+  justify-content: space-between;
+  box-sizing: content-box !important;
+  width: 176px;
+  padding: 8px;
+  border-radius: 3px;
+}
+.color-picker--advanced-fields[data-v-cc496c1d] {
+  width: 264px;
+}
+.color-picker__simple[data-v-cc496c1d] {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, var(--default-clickable-area));
+  grid-auto-rows: var(--default-clickable-area);
+}
+.color-picker__simple-color-circle[data-v-cc496c1d] {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: calc(var(--default-clickable-area) - 10px);
+  height: calc(var(--default-clickable-area) - 10px);
+  min-height: calc(var(--default-clickable-area) - 10px);
+  margin: auto;
+  padding: 0;
+  color: white;
+  border: 1px solid rgba(0, 0, 0, 0.25);
+  border-radius: 50%;
+  font-size: 16px;
+}
+.color-picker__simple-color-circle[data-v-cc496c1d]:focus-within {
+  outline: 2px solid var(--color-main-text);
+}
+.color-picker__simple-color-circle[data-v-cc496c1d]:hover {
+  opacity: 0.6;
+}
+.color-picker__simple-color-circle--active[data-v-cc496c1d] {
+  width: calc(var(--default-clickable-area) - 6px);
+  height: calc(var(--default-clickable-area) - 6px);
+  min-height: calc(var(--default-clickable-area) - 6px);
+  transition: all 100ms ease-in-out;
+  opacity: 1 !important;
+}
+.color-picker__advanced[data-v-cc496c1d] {
+  box-shadow: none !important;
+}
+.color-picker__navigation[data-v-cc496c1d] {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  margin-top: 10px;
+}
+[data-v-cc496c1d]  .vc-chrome {
+  width: unset;
+  background-color: var(--color-main-background);
+}
+[data-v-cc496c1d]  .vc-chrome-color-wrap {
+  width: 30px;
+  height: 30px;
+}
+[data-v-cc496c1d]  .vc-chrome-active-color {
+  width: calc(var(--default-clickable-area) - 10 px);
+  height: calc(var(--default-clickable-area) - 10 px);
+  border-radius: 17px;
+}
+[data-v-cc496c1d]  .vc-chrome-body {
+  padding: 14px 0 0 0;
+  background-color: var(--color-main-background);
+}
+[data-v-cc496c1d]  .vc-chrome-body .vc-input__input {
+  box-shadow: none;
+}
+[data-v-cc496c1d]  .vc-chrome-toggle-btn {
+  filter: var(--background-invert-if-dark);
+}
+[data-v-cc496c1d]  .vc-chrome-saturation-wrap {
+  border-radius: 3px;
+}
+[data-v-cc496c1d]  .vc-chrome-saturation-circle {
+  width: 20px;
+  height: 20px;
+}
+.slide-enter[data-v-cc496c1d] {
+  transform: translateX(-50%);
+  opacity: 0;
+}
+.slide-enter-to[data-v-cc496c1d] {
+  transform: translateX(0);
+  opacity: 1;
+}
+.slide-leave[data-v-cc496c1d] {
+  transform: translateX(0);
+  opacity: 1;
+}
+.slide-leave-to[data-v-cc496c1d] {
+  transform: translateX(-50%);
+  opacity: 0;
+}
+.slide-enter-active[data-v-cc496c1d], .slide-leave-active[data-v-cc496c1d] {
+  transition: all 50ms ease-in-out;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+#skip-actions.vue-skip-actions:focus-within {
+  top: 0 !important;
+  left: 0 !important;
+  width: 100vw;
+  height: 100vh;
+  padding: var(--body-container-margin) !important;
+  backdrop-filter: brightness(50%);
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-d8f0539f] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.vue-skip-actions__container[data-v-d8f0539f] {
+  background-color: var(--color-main-background);
+  border-radius: var(--border-radius-large);
+  padding: 22px;
+}
+.vue-skip-actions__headline[data-v-d8f0539f] {
+  font-weight: bold;
+  font-size: 20px;
+  line-height: 30px;
+  margin-bottom: 12px;
+}
+.vue-skip-actions__buttons[data-v-d8f0539f] {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+.vue-skip-actions__buttons > *[data-v-d8f0539f] {
+  flex: 1 0 fit-content;
+}
+.vue-skip-actions__image[data-v-d8f0539f] {
+  margin-top: 12px;
+}
+.content[data-v-d8f0539f] {
+  box-sizing: border-box;
+  margin: var(--body-container-margin);
+  margin-top: var(--header-height);
+  display: flex;
+  width: calc(100% - var(--body-container-margin) * 2);
+  border-radius: var(--body-container-radius);
+  height: var(--body-height);
+  overflow: hidden;
+  padding: 0;
+}
+.content[data-v-d8f0539f]:not(.with-sidebar--full) {
+  position: fixed;
+}
+.content[data-v-d8f0539f] * {
+  box-sizing: border-box;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-11322bad] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.counter-bubble__counter[data-v-11322bad] {
+  --counter-bubble-height: 22px;
+  font-size: var(--font-size-small, 13px);
+  overflow: hidden;
+  width: fit-content;
+  min-width: var(--counter-bubble-height);
+  text-align: center;
+  line-height: var(--counter-bubble-height);
+  padding: 0 calc(1.5 * var(--default-grid-baseline));
+  border-radius: var(--border-radius-pill);
+  background-color: var(--color-primary-element-light);
+  font-weight: bold;
+  color: var(--color-primary-element-light-text);
+}
+.counter-bubble__counter .active[data-v-11322bad] {
+  color: var(--color-main-background);
+  background-color: var(--color-primary-element-light);
+}
+.counter-bubble__counter--highlighted[data-v-11322bad] {
+  color: var(--color-primary-element-text);
+  background-color: var(--color-primary-element);
+}
+.counter-bubble__counter--highlighted.active[data-v-11322bad] {
+  color: var(--color-primary-element);
+  background-color: var(--color-main-background);
+}
+.counter-bubble__counter--outlined[data-v-11322bad] {
+  color: var(--color-primary-element);
+  background: transparent;
+  box-shadow: inset 0 0 0 2px;
+}
+.counter-bubble__counter--outlined.active[data-v-11322bad] {
+  color: var(--color-main-background);
+  box-shadow: inset 0 0 0 2px;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-53796b97] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.dashboard-widget[data-v-53796b97] .empty-content {
+  text-align: center;
+  padding-top: 5vh;
+}
+.dashboard-widget[data-v-53796b97] .empty-content.half-screen {
+  padding-top: 0;
+  margin-bottom: 1vh;
+}
+.more[data-v-53796b97] {
+  display: block;
+  text-align: center;
+  color: var(--color-text-maxcontrast);
+  line-height: 60px;
+  cursor: pointer;
+}
+.more[data-v-53796b97]:hover, .more[data-v-53796b97]:focus {
+  background-color: var(--color-background-hover);
+  border-radius: var(--border-radius-large);
+  color: var(--color-main-text);
+}
+
+/* skeleton */
+.item-list__entry[data-v-53796b97] {
+  display: flex;
+  align-items: flex-start;
+  padding: 8px;
+}
+.item-list__entry .item-avatar[data-v-53796b97] {
+  position: relative;
+  margin-top: auto;
+  margin-bottom: auto;
+  background-color: var(--color-background-dark) !important;
+}
+.item-list__entry .item__details[data-v-53796b97] {
+  padding-left: 8px;
+  max-height: var(--default-clickable-area);
+  flex-grow: 1;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+.item-list__entry .item__details h3[data-v-53796b97],
+.item-list__entry .item__details .message[data-v-53796b97] {
+  white-space: nowrap;
+  background-color: var(--color-background-dark);
+}
+.item-list__entry .item__details h3[data-v-53796b97] {
+  font-size: 100%;
+  margin: 0;
+}
+.item-list__entry .item__details .message[data-v-53796b97] {
+  width: 80%;
+  height: 15px;
+  margin-top: 5px;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-51bbc625] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.item-list__entry[data-v-51bbc625] {
+  display: flex;
+  align-items: center;
+  position: relative;
+  padding: 8px;
+}
+.item-list__entry[data-v-51bbc625]:hover, .item-list__entry[data-v-51bbc625]:focus {
+  background-color: var(--color-background-hover);
+  border-radius: var(--border-radius-large);
+}
+.item-list__entry .item-avatar[data-v-51bbc625] {
+  position: relative;
+  margin-top: auto;
+  margin-bottom: auto;
+}
+.item-list__entry .item__details[data-v-51bbc625] {
+  padding-left: 8px;
+  max-height: fit-content;
+  flex-grow: 1;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  min-height: var(--default-clickable-area);
+}
+.item-list__entry .item__details h3[data-v-51bbc625],
+.item-list__entry .item__details .message[data-v-51bbc625] {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.item-list__entry .item__details .message span[data-v-51bbc625] {
+  width: 10px;
+  display: inline-block;
+  margin-bottom: -3px;
+}
+.item-list__entry .item__details h3[data-v-51bbc625] {
+  font-size: 100%;
+  margin: 0;
+}
+.item-list__entry .item__details .message[data-v-51bbc625] {
+  width: 100%;
+  color: var(--color-text-maxcontrast);
+}
+.item-list__entry .item-icon[data-v-51bbc625] {
+  position: relative;
+  width: 14px;
+  height: 14px;
+  margin: 27px -3px 0px -7px;
+}
+.item-list__entry button.primary[data-v-51bbc625] {
+  padding: 21px;
+  margin: 0;
+}
+
+/*
+.content-popover {
+	height: 0px;
+	width: 0px;
+	margin-left: auto;
+	margin-right: auto;
+}
+.popover-container {
+	width: 100%;
+	height: 0px;
+}
+*//**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.emoji-mart,
+.emoji-mart * {
+  box-sizing: border-box;
+  line-height: 1.15;
+}
+.emoji-mart {
+  font-family: -apple-system, BlinkMacSystemFont, 'Helvetica Neue', sans-serif;
+  font-size: 16px;
+  /* display: inline-block; */
+  display: flex;
+  flex-direction: column;
+  height: 420px;
+  color: #222427;
+  border: 1px solid #d9d9d9;
+  border-radius: 5px;
+  background: #fff;
+}
+.emoji-mart-emoji {
+  padding: 6px;
+  position: relative;
+  display: inline-block;
+  font-size: 0;
+  border: none;
+  background: none;
+  box-shadow: none;
+}
+.emoji-mart-emoji span {
+  display: inline-block;
+}
+.emoji-mart-preview-emoji .emoji-mart-emoji span {
+  width: 38px;
+  height: 38px;
+  font-size: 32px;
+}
+.emoji-type-native {
+  font-family: 'Segoe UI Emoji', 'Segoe UI Symbol', 'Segoe UI',
+    'Apple Color Emoji', 'Twemoji Mozilla', 'Noto Color Emoji', 'EmojiOne Color',
+    'Android Emoji';
+  word-break: keep-all;
+}
+.emoji-type-image {
+  /* Emoji sheet has 56 columns, see also utils/emoji-data.js, SHEET_COLUMNS variable */
+  /* Here we use (56+1) * 100% to avoid visible edges of nearby icons when scaling for different
+   * screen sizes */
+  background-size: 6100%;
+}
+.emoji-type-image.emoji-set-apple {
+  background-image: url('https://unpkg.com/emoji-datasource-apple@15.0.1/img/apple/sheets-256/64.png');
+}
+.emoji-type-image.emoji-set-facebook {
+  background-image: url('https://unpkg.com/emoji-datasource-facebook@15.0.1/img/facebook/sheets-256/64.png');
+}
+.emoji-type-image.emoji-set-google {
+  background-image: url('https://unpkg.com/emoji-datasource-google@15.0.1/img/google/sheets-256/64.png');
+}
+.emoji-type-image.emoji-set-twitter {
+  background-image: url('https://unpkg.com/emoji-datasource-twitter@15.0.1/img/twitter/sheets-256/64.png');
+}
+.emoji-mart-bar {
+  border: 0 solid #d9d9d9;
+}
+.emoji-mart-bar:first-child {
+  border-bottom-width: 1px;
+  border-top-left-radius: 5px;
+  border-top-right-radius: 5px;
+}
+.emoji-mart-bar:last-child {
+  border-top-width: 1px;
+  border-bottom-left-radius: 5px;
+  border-bottom-right-radius: 5px;
+}
+.emoji-mart-scroll {
+  position: relative;
+  overflow-y: scroll;
+  flex: 1;
+  padding: 0 6px 6px 6px;
+  z-index: 0; /* Fix for rendering sticky positioned category labels on Chrome */
+  will-change: transform; /* avoids "repaints on scroll" in mobile Chrome */
+  -webkit-overflow-scrolling: touch;
+}
+.emoji-mart-anchors {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  padding: 0 6px;
+  color: #858585;
+  line-height: 0;
+}
+.emoji-mart-anchor {
+  position: relative;
+  display: block;
+  flex: 1 1 auto;
+  text-align: center;
+  padding: 12px 4px;
+  overflow: hidden;
+  transition: color 0.1s ease-out;
+  border: none;
+  background: none;
+  box-shadow: none;
+}
+.emoji-mart-anchor:hover,
+.emoji-mart-anchor-selected {
+  color: #464646;
+}
+.emoji-mart-anchor-selected .emoji-mart-anchor-bar {
+  bottom: 0;
+}
+.emoji-mart-anchor-bar {
+  position: absolute;
+  bottom: -3px;
+  left: 0;
+  width: 100%;
+  height: 3px;
+  background-color: #464646;
+}
+.emoji-mart-anchors i {
+  display: inline-block;
+  width: 100%;
+  max-width: 22px;
+}
+.emoji-mart-anchors svg {
+  fill: currentColor;
+  max-height: 18px;
+}
+.emoji-mart .scroller {
+  height: 250px;
+  position: relative;
+  flex: 1;
+  padding: 0 6px 6px 6px;
+  z-index: 0; /* Fix for rendering sticky positioned category labels on Chrome */
+  will-change: transform; /* avoids "repaints on scroll" in mobile Chrome */
+  -webkit-overflow-scrolling: touch;
+}
+.emoji-mart-search {
+  margin-top: 6px;
+  padding: 0 6px;
+}
+.emoji-mart-search input {
+  font-size: 16px;
+  display: block;
+  width: 100%;
+  padding: 0.2em 0.6em;
+  border-radius: 25px;
+  border: 1px solid #d9d9d9;
+  outline: 0;
+}
+.emoji-mart-search-results {
+  height: 250px;
+  overflow-y: scroll;
+}
+.emoji-mart-category {
+  position: relative;
+}
+.emoji-mart-category .emoji-mart-emoji span {
+  z-index: 1;
+  position: relative;
+  text-align: center;
+  cursor: default;
+}
+.emoji-mart-category .emoji-mart-emoji:hover:before,
+.emoji-mart-emoji-selected:before {
+  z-index: 0;
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: #f4f4f4;
+  border-radius: 100%;
+  opacity: 0;
+}
+.emoji-mart-category .emoji-mart-emoji:hover:before,
+.emoji-mart-emoji-selected:before {
+  opacity: 1;
+}
+.emoji-mart-category-label {
+  position: sticky;
+  top: 0;
+}
+.emoji-mart-static .emoji-mart-category-label {
+  z-index: 2;
+  position: relative;
+  /* position: sticky; */
+  /* position: -webkit-sticky; */
+}
+.emoji-mart-category-label h3 {
+  display: block;
+  font-size: 16px;
+  width: 100%;
+  font-weight: 500;
+  padding: 5px 6px;
+  background-color: #fff;
+  background-color: rgba(255, 255, 255, 0.95);
+}
+.emoji-mart-emoji {
+  position: relative;
+  display: inline-block;
+  font-size: 0;
+}
+.emoji-mart-no-results {
+  font-size: 14px;
+  text-align: center;
+  padding-top: 70px;
+  color: #858585;
+}
+.emoji-mart-no-results .emoji-mart-category-label {
+  display: none;
+}
+.emoji-mart-no-results .emoji-mart-no-results-label {
+  margin-top: 0.2em;
+}
+.emoji-mart-no-results .emoji-mart-emoji:hover:before {
+  content: none;
+}
+.emoji-mart-preview {
+  position: relative;
+  height: 70px;
+}
+.emoji-mart-preview-emoji,
+.emoji-mart-preview-data,
+.emoji-mart-preview-skins {
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+}
+.emoji-mart-preview-emoji {
+  left: 12px;
+}
+.emoji-mart-preview-data {
+  left: 68px;
+  right: 12px;
+  word-break: break-all;
+}
+.emoji-mart-preview-skins {
+  right: 30px;
+  text-align: right;
+}
+.emoji-mart-preview-name {
+  font-size: 14px;
+}
+.emoji-mart-preview-shortname {
+  font-size: 12px;
+  color: #888;
+}
+.emoji-mart-preview-shortname + .emoji-mart-preview-shortname,
+.emoji-mart-preview-shortname + .emoji-mart-preview-emoticon,
+.emoji-mart-preview-emoticon + .emoji-mart-preview-emoticon {
+  margin-left: 0.5em;
+}
+.emoji-mart-preview-emoticon {
+  font-size: 11px;
+  color: #bbb;
+}
+.emoji-mart-title span {
+  display: inline-block;
+  vertical-align: middle;
+}
+.emoji-mart-title .emoji-mart-emoji {
+  padding: 0;
+}
+.emoji-mart-title-label {
+  color: #999a9c;
+  font-size: 21px;
+  font-weight: 300;
+}
+.emoji-mart-skin-swatches {
+  font-size: 0;
+  padding: 2px 0;
+  border: 1px solid #d9d9d9;
+  border-radius: 12px;
+  background-color: #fff;
+}
+.emoji-mart-skin-swatches-opened .emoji-mart-skin-swatch {
+  width: 16px;
+  padding: 0 2px;
+}
+.emoji-mart-skin-swatches-opened .emoji-mart-skin-swatch-selected:after {
+  opacity: 0.75;
+}
+.emoji-mart-skin-swatch {
+  display: inline-block;
+  width: 0;
+  vertical-align: middle;
+  transition-property: width, padding;
+  transition-duration: 0.125s;
+  transition-timing-function: ease-out;
+}
+.emoji-mart-skin-swatch:nth-child(1) {
+  transition-delay: 0s;
+}
+.emoji-mart-skin-swatch:nth-child(2) {
+  transition-delay: 0.03s;
+}
+.emoji-mart-skin-swatch:nth-child(3) {
+  transition-delay: 0.06s;
+}
+.emoji-mart-skin-swatch:nth-child(4) {
+  transition-delay: 0.09s;
+}
+.emoji-mart-skin-swatch:nth-child(5) {
+  transition-delay: 0.12s;
+}
+.emoji-mart-skin-swatch:nth-child(6) {
+  transition-delay: 0.15s;
+}
+.emoji-mart-skin-swatch-selected {
+  position: relative;
+  width: 16px;
+  padding: 0 2px;
+}
+.emoji-mart-skin-swatch-selected:after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 4px;
+  height: 4px;
+  margin: -2px 0 0 -2px;
+  background-color: #fff;
+  border-radius: 100%;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.2s ease-out;
+}
+.emoji-mart-skin {
+  display: inline-block;
+  width: 100%;
+  padding-top: 100%;
+  max-width: 12px;
+  border-radius: 100%;
+}
+.emoji-mart-skin-tone-1 {
+  background-color: #ffc93a;
+}
+.emoji-mart-skin-tone-2 {
+  background-color: #fadcbc;
+}
+.emoji-mart-skin-tone-3 {
+  background-color: #e0bb95;
+}
+.emoji-mart-skin-tone-4 {
+  background-color: #bf8f68;
+}
+.emoji-mart-skin-tone-5 {
+  background-color: #9b643d;
+}
+.emoji-mart-skin-tone-6 {
+  background-color: #594539;
+}
+/* vue-virtual-scroller/dist/vue-virtual-scroller.css */
+.emoji-mart .vue-recycle-scroller {
+  position: relative;
+}
+.emoji-mart .vue-recycle-scroller.direction-vertical:not(.page-mode) {
+  overflow-y: auto;
+}
+.emoji-mart .vue-recycle-scroller.direction-horizontal:not(.page-mode) {
+  overflow-x: auto;
+}
+.emoji-mart .vue-recycle-scroller.direction-horizontal {
+  display: flex;
+}
+.emoji-mart .vue-recycle-scroller__slot {
+  flex: auto 0 0;
+}
+.emoji-mart .vue-recycle-scroller__item-wrapper {
+  flex: 1;
+  box-sizing: border-box;
+  overflow: hidden;
+  position: relative;
+}
+.emoji-mart .vue-recycle-scroller.ready .vue-recycle-scroller__item-view {
+  position: absolute;
+  top: 0;
+  left: 0;
+  will-change: transform;
+}
+.emoji-mart
+  .vue-recycle-scroller.direction-vertical
+  .vue-recycle-scroller__item-wrapper {
+  width: 100%;
+}
+.emoji-mart
+  .vue-recycle-scroller.direction-horizontal
+  .vue-recycle-scroller__item-wrapper {
+  height: 100%;
+}
+.emoji-mart
+  .vue-recycle-scroller.ready.direction-vertical
+  .vue-recycle-scroller__item-view {
+  width: 100%;
+}
+.emoji-mart
+  .vue-recycle-scroller.ready.direction-horizontal
+  .vue-recycle-scroller__item-view {
+  height: 100%;
+}
+.emoji-mart .resize-observer[data-v-b329ee4c] {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: -1;
+  width: 100%;
+  height: 100%;
+  border: none;
+  background-color: transparent;
+  pointer-events: none;
+  display: block;
+  overflow: hidden;
+  opacity: 0;
+}
+.emoji-mart .resize-observer[data-v-b329ee4c] object {
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
+  pointer-events: none;
+  z-index: -1;
+}
+.emoji-mart-search .hidden {
+  display: none;
+  visibility: hidden;
+}
+.material-design-icon {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.emoji-mart {
+  background-color: var(--color-main-background) !important;
+  border: 0;
+  color: var(--color-main-text) !important;
+}
+.emoji-mart button {
+  margin: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+  font-size: inherit;
+  height: 36px;
+  width: auto;
+}
+.emoji-mart button * {
+  cursor: pointer !important;
+}
+.emoji-mart .emoji-mart-bar,
+.emoji-mart .emoji-mart-anchors,
+.emoji-mart .emoji-mart-search,
+.emoji-mart .emoji-mart-search input,
+.emoji-mart .emoji-mart-category,
+.emoji-mart .emoji-mart-category-label,
+.emoji-mart .emoji-mart-category-label span,
+.emoji-mart .emoji-mart-skin-swatches {
+  background-color: transparent !important;
+  border-color: var(--color-border) !important;
+  color: inherit !important;
+}
+.emoji-mart .emoji-mart-search input:focus-visible {
+  box-shadow: inset 0 0 0 2px var(--color-primary-element);
+  outline: none;
+}
+.emoji-mart .emoji-mart-bar:first-child {
+  border-top-left-radius: var(--border-radius) !important;
+  border-top-right-radius: var(--border-radius) !important;
+}
+.emoji-mart .emoji-mart-anchors button {
+  border-radius: 0;
+  padding: 12px 4px;
+  height: auto;
+}
+.emoji-mart .emoji-mart-anchors button:focus-visible {
+  /* box-shadow: inset 0 0 0 2px var(--color-primary-element); */
+  outline: 2px solid var(--color-primary-element);
+}
+.emoji-mart .emoji-mart-category {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  justify-content: start;
+}
+.emoji-mart .emoji-mart-category .emoji-mart-category-label,
+.emoji-mart .emoji-mart-category .emoji-mart-emoji {
+  user-select: none;
+  flex-grow: 0;
+  flex-shrink: 0;
+}
+.emoji-mart .emoji-mart-category .emoji-mart-category-label {
+  flex-basis: 100%;
+  margin: 0;
+}
+.emoji-mart .emoji-mart-category .emoji-mart-emoji {
+  flex-basis: 12.5%;
+  text-align: center;
+}
+.emoji-mart .emoji-mart-category .emoji-mart-emoji:hover::before, .emoji-mart .emoji-mart-category .emoji-mart-emoji.emoji-mart-emoji-selected::before {
+  background-color: var(--color-background-hover) !important;
+  outline: 2px solid var(--color-primary-element);
+}
+.emoji-mart .emoji-mart-category button:focus-visible {
+  background-color: var(--color-background-hover);
+  border: 2px solid var(--color-primary-element) !important;
+  border-radius: 50%;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-6c2d9a6e] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.search__wrapper[data-v-6c2d9a6e] {
+  display: flex;
+  flex-direction: row;
+  gap: 4px;
+  align-items: end;
+  padding: 4px 8px;
+}
+.row-selected button[data-v-6c2d9a6e], .row-selected span[data-v-6c2d9a6e] {
+  vertical-align: middle;
+}
+.emoji-delete[data-v-6c2d9a6e] {
+  vertical-align: top;
+  margin-left: -21px;
+  margin-top: -3px;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-cbad78fb] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+#guest-content-vue[data-v-cbad78fb] {
+  color: var(--color-main-text);
+  background-color: var(--color-main-background);
+  min-width: 0;
+  border-radius: var(--border-radius-large);
+  box-shadow: 0 0 10px var(--color-box-shadow);
+  height: fit-content;
+  padding: 15px;
+  margin: 20px auto;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+#content.nc-guest-content {
+  overflow: auto;
+  margin-bottom: 0;
+  height: calc(var(--body-height) + var(--body-container-margin));
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-2d5ac9dc] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.header-menu[data-v-2d5ac9dc] {
+  position: relative;
+  width: var(--header-height);
+  height: var(--header-height);
+}
+.header-menu .header-menu__trigger[data-v-2d5ac9dc] {
+  width: 100% !important;
+  height: var(--header-height);
+  opacity: 0.85;
+  filter: none !important;
+  color: var(--color-background-plain-text, var(--color-primary-text)) !important;
+}
+.header-menu--opened .header-menu__trigger[data-v-2d5ac9dc], .header-menu__trigger[data-v-2d5ac9dc]:hover, .header-menu__trigger[data-v-2d5ac9dc]:focus, .header-menu__trigger[data-v-2d5ac9dc]:active {
+  opacity: 1;
+}
+.header-menu .header-menu__trigger[data-v-2d5ac9dc]:focus-visible {
+  outline: none !important;
+  box-shadow: none !important;
+}
+.header-menu__wrapper[data-v-2d5ac9dc] {
+  position: fixed;
+  z-index: 2000;
+  top: var(--header-height);
+  inset-inline-end: 0;
+  box-sizing: border-box;
+  margin: 0 8px;
+  padding: 8px;
+  border-radius: 0 0 var(--border-radius) var(--border-radius);
+  border-radius: var(--border-radius-large);
+  background-color: var(--color-main-background);
+  filter: drop-shadow(0 1px 5px var(--color-box-shadow));
+}
+.header-menu__carret[data-v-2d5ac9dc] {
+  position: absolute;
+  z-index: 2001;
+  bottom: 0;
+  inset-inline-start: calc(50% - 10px);
+  width: 0;
+  height: 0;
+  content: " ";
+  pointer-events: none;
+  border: 10px solid transparent;
+  border-bottom-color: var(--color-main-background);
+}
+.header-menu__content[data-v-2d5ac9dc] {
+  overflow: auto;
+  width: 350px;
+  max-width: calc(100vw - 16px);
+  min-height: calc(var(--default-clickable-area) * 1.5);
+  max-height: calc(100vh - var(--header-height) * 2);
+}
+.header-menu__content[data-v-2d5ac9dc] .empty-content {
+  margin: 12vh 10px;
+}
+@media only screen and (max-width: 512px) {
+.header-menu[data-v-2d5ac9dc] {
+    width: var(--default-clickable-area);
+}
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-a3ec46a7] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.list-item__wrapper[data-v-a3ec46a7] {
+  display: flex;
+  position: relative;
+  width: 100%;
+  padding: 2px 4px;
+}
+.list-item__wrapper[data-v-a3ec46a7]:first-of-type {
+  padding-block-start: 4px;
+}
+.list-item__wrapper[data-v-a3ec46a7]:last-of-type {
+  padding-block-end: 4px;
+}
+.list-item__wrapper--active .list-item[data-v-a3ec46a7], .list-item__wrapper.active .list-item[data-v-a3ec46a7] {
+  background-color: var(--color-primary-element);
+  color: var(--color-primary-element-text) !important;
+}
+.list-item__wrapper--active .list-item[data-v-a3ec46a7]:hover, .list-item__wrapper--active .list-item[data-v-a3ec46a7]:focus-within, .list-item__wrapper--active .list-item[data-v-a3ec46a7]:has(:focus-visible), .list-item__wrapper--active .list-item[data-v-a3ec46a7]:has(:active), .list-item__wrapper.active .list-item[data-v-a3ec46a7]:hover, .list-item__wrapper.active .list-item[data-v-a3ec46a7]:focus-within, .list-item__wrapper.active .list-item[data-v-a3ec46a7]:has(:focus-visible), .list-item__wrapper.active .list-item[data-v-a3ec46a7]:has(:active) {
+  background-color: var(--color-primary-element-hover);
+}
+.list-item__wrapper--active .list-item-content__name[data-v-a3ec46a7],
+.list-item__wrapper--active .list-item-content__subname[data-v-a3ec46a7],
+.list-item__wrapper--active .list-item-content__details[data-v-a3ec46a7],
+.list-item__wrapper--active .list-item-details__details[data-v-a3ec46a7], .list-item__wrapper.active .list-item-content__name[data-v-a3ec46a7],
+.list-item__wrapper.active .list-item-content__subname[data-v-a3ec46a7],
+.list-item__wrapper.active .list-item-content__details[data-v-a3ec46a7],
+.list-item__wrapper.active .list-item-details__details[data-v-a3ec46a7] {
+  color: var(--color-primary-element-text) !important;
+}
+.list-item__wrapper .list-item-content__name[data-v-a3ec46a7],
+.list-item__wrapper .list-item-content__subname[data-v-a3ec46a7],
+.list-item__wrapper .list-item-content__details[data-v-a3ec46a7],
+.list-item__wrapper .list-item-details__details[data-v-a3ec46a7] {
+  white-space: nowrap;
+  margin: 0 auto 0 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.list-item-content__name[data-v-a3ec46a7] {
+  min-width: 100px;
+  flex: 1 1 10%;
+  font-weight: 500;
+}
+.list-item-content__subname[data-v-a3ec46a7] {
+  flex: 1 0;
+  min-width: 0;
+  color: var(--color-text-maxcontrast);
+}
+.list-item-content__subname--bold[data-v-a3ec46a7] {
+  font-weight: 500;
+}
+.list-item[data-v-a3ec46a7] {
+  --list-item-padding: var(--default-grid-baseline);
+  --list-item-height: 2lh;
+  --list-item-border-radius: var(--border-radius-element, 32px);
+  box-sizing: border-box;
+  display: flex;
+  position: relative;
+  flex: 0 0 auto;
+  justify-content: flex-start;
+  padding: var(--list-item-padding);
+  width: 100%;
+  border-radius: var(--border-radius-element, 32px);
+  cursor: pointer;
+  transition: background-color var(--animation-quick) ease-in-out;
+  list-style: none;
+}
+.list-item[data-v-a3ec46a7]:hover, .list-item[data-v-a3ec46a7]:focus-within, .list-item[data-v-a3ec46a7]:has(:active), .list-item[data-v-a3ec46a7]:has(:focus-visible) {
+  background-color: var(--color-background-hover);
+}
+.list-item[data-v-a3ec46a7]:has(.list-item__anchor:focus-visible) {
+  outline: 2px solid var(--color-main-text);
+  box-shadow: 0 0 0 4px var(--color-main-background);
+}
+.list-item--compact[data-v-a3ec46a7] {
+  --list-item-padding: calc(0.5 * var(--default-grid-baseline)) var(--default-grid-baseline);
+}
+.list-item--compact[data-v-a3ec46a7]:not(:has(.list-item-content__subname)) {
+  --list-item-height: var(--default-clickable-area);
+}
+.list-item--legacy[data-v-a3ec46a7] {
+  --list-item-padding: calc(2 * var(--default-grid-baseline));
+}
+.list-item--legacy.list-item--compact[data-v-a3ec46a7] {
+  --list-item-padding: var(--default-grid-baseline) calc(2 * var(--default-grid-baseline));
+}
+.list-item--one-line[data-v-a3ec46a7] {
+  --list-item-height: var(--default-clickable-area);
+  --list-item-border-radius: var(--border-radius-element, calc(var(--default-clickable-area) / 2));
+  --list-item-padding: var(--default-grid-baseline);
+}
+.list-item--one-line.list-item--one-line--legacy[data-v-a3ec46a7] {
+  --list-item-padding: 2px calc((var(--list-item-height) - var(--list-item-border-radius)) / 2);
+}
+.list-item--one-line .list-item-content__main[data-v-a3ec46a7] {
+  display: flex;
+  justify-content: start;
+  gap: 12px;
+  min-width: 0;
+  max-width: 300px;
+}
+.list-item--one-line .list-item-content__details[data-v-a3ec46a7] {
+  flex-direction: row;
+  align-items: unset;
+  justify-content: end;
+}
+.list-item--one-line .list-item-content__name[data-v-a3ec46a7] {
+  align-self: center;
+}
+.list-item__anchor[data-v-a3ec46a7] {
+  color: inherit;
+  display: flex;
+  flex: 1 0 auto;
+  align-items: center;
+  height: var(--list-item-height);
+  min-width: 0;
+}
+.list-item__anchor[data-v-a3ec46a7]:focus-visible {
+  outline: none;
+}
+.list-item-content[data-v-a3ec46a7] {
+  display: flex;
+  flex: 1 0;
+  justify-content: space-between;
+  padding-left: calc(2 * var(--default-grid-baseline));
+  min-width: 0;
+}
+.list-item-content__main[data-v-a3ec46a7] {
+  flex: 1 0;
+  width: 0;
+  margin: auto 0;
+}
+.list-item-content__main--oneline[data-v-a3ec46a7] {
+  display: flex;
+}
+.list-item-content__details[data-v-a3ec46a7] {
+  display: flex;
+  flex-direction: column;
+  justify-content: end;
+  align-items: end;
+}
+.list-item-content__actions[data-v-a3ec46a7], .list-item-content__extra-actions[data-v-a3ec46a7] {
+  flex: 0 0 auto;
+  align-self: center;
+  justify-content: center;
+  margin-left: var(--default-grid-baseline);
+}
+.list-item-content__extra-actions[data-v-a3ec46a7] {
+  display: flex;
+  align-items: center;
+  gap: var(--default-grid-baseline);
+}
+.list-item-details__details[data-v-a3ec46a7] {
+  color: var(--color-text-maxcontrast);
+  margin: 0 9px !important;
+  font-weight: normal;
+}
+.list-item-details__extra[data-v-a3ec46a7] {
+  margin: 2px 4px 0 4px;
+  display: flex;
+  align-items: center;
+}
+.list-item-details__indicator[data-v-a3ec46a7] {
+  margin: 0 5px;
+}
+.list-item__extra[data-v-a3ec46a7] {
+  margin-top: var(--default-grid-baseline);
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-5e97fe1f] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.progress-bar[data-v-5e97fe1f] {
+  display: block;
+  height: var(--progress-bar-height);
+  --progress-bar-color: var(--497e8a2b);
+}
+.progress-bar--linear[data-v-5e97fe1f] {
+  width: 100%;
+  overflow: hidden;
+  border: 0;
+  padding: 0;
+  background: var(--color-background-dark);
+  border-radius: calc(var(--progress-bar-height) / 2);
+}
+.progress-bar--linear[data-v-5e97fe1f]::-webkit-progress-bar {
+  height: var(--progress-bar-height);
+  background-color: transparent;
+}
+.progress-bar--linear[data-v-5e97fe1f]::-webkit-progress-value {
+  background: var(--progress-bar-color, var(--gradient-primary-background));
+  border-radius: calc(var(--progress-bar-height) / 2);
+}
+.progress-bar--linear[data-v-5e97fe1f]::-moz-progress-bar {
+  background: var(--progress-bar-color, var(--gradient-primary-background));
+  border-radius: calc(var(--progress-bar-height) / 2);
+}
+.progress-bar--circular[data-v-5e97fe1f] {
+  width: var(--progress-bar-height);
+  color: var(--progress-bar-color, var(--color-primary-element));
+}
+.progress-bar--error[data-v-5e97fe1f] {
+  color: var(--color-error) !important;
+}
+.progress-bar--error[data-v-5e97fe1f]::-moz-progress-bar {
+  background: var(--color-error) !important;
+}
+.progress-bar--error[data-v-5e97fe1f]::-webkit-progress-value {
+  background: var(--color-error) !important;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-de46bdbe] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.team-resources__header[data-v-de46bdbe] {
+  font-weight: bold;
+  margin-bottom: 6px;
+}
+.related-team[data-v-de46bdbe] {
+  border-radius: var(--border-radius-rounded);
+  border: 2px solid var(--color-border-dark);
+  margin-bottom: 6px;
+}
+.related-team__open[data-v-de46bdbe] {
+  border-color: var(--color-primary-element);
+}
+.related-team__header[data-v-de46bdbe] {
+  padding: 6px;
+  padding-right: 24px;
+  display: flex;
+  gap: 12px;
+}
+.related-team__name[data-v-de46bdbe] {
+  display: flex;
+  flex-grow: 1;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 12px;
+  font-weight: bold;
+  margin: 0;
+}
+.related-team .related-team-provider[data-v-de46bdbe] {
+  padding: 6px 12px;
+}
+.related-team .related-team-provider__name[data-v-de46bdbe] {
+  font-weight: bold;
+  margin-bottom: 3px;
+}
+.related-team .related-team-provider__link[data-v-de46bdbe] {
+  display: flex;
+  gap: 12px;
+  padding: 6px 12px;
+  font-weight: bold;
+}
+.related-team .related-team-resource__link[data-v-de46bdbe] {
+  display: flex;
+  gap: 12px;
+  height: var(--default-clickable-area);
+  align-items: center;
+  border-radius: var(--border-radius-large);
+}
+.related-team .related-team-resource__link[data-v-de46bdbe]:hover {
+  background-color: var(--color-background-hover);
+}
+.related-team .related-team-resource__link[data-v-de46bdbe]:focus {
+  background-color: var(--color-background-hover);
+  outline: 2px solid var(--color-primary-element);
+}
+.related-team .related-team-resource .resource__icon[data-v-de46bdbe] {
+  width: var(--default-clickable-area);
+  height: var(--default-clickable-area);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+}
+.related-team .related-team-resource .resource__icon > img[data-v-de46bdbe] {
+  border-radius: var(--border-radius-pill);
+  overflow: hidden;
+  width: 32px;
+  height: 32px;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-ac1115a7] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.resource[data-v-ac1115a7] {
+  display: flex;
+  align-items: center;
+  height: var(--default-clickable-area);
+}
+.resource__button[data-v-ac1115a7] {
+  width: 100% !important;
+  justify-content: flex-start !important;
+  padding: 0 !important;
+}
+.resource__button[data-v-ac1115a7] .button-vue__wrapper {
+  justify-content: flex-start !important;
+}
+.resource__button[data-v-ac1115a7] .button-vue__wrapper .button-vue__text {
+  font-weight: normal !important;
+  margin-left: 2px !important;
+}
+.resource__icon[data-v-ac1115a7] {
+  width: 32px;
+  height: 32px;
+  background-color: var(--color-text-maxcontrast);
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.resource__icon img[data-v-ac1115a7] {
+  width: 16px;
+  height: 16px;
+  filter: var(--background-invert-if-dark);
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-badd46a9] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.related-resources__header h5[data-v-badd46a9] {
+  font-weight: bold;
+  margin-bottom: 6px;
+}
+.related-resources__header p[data-v-badd46a9] {
+  color: var(--color-text-maxcontrast);
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-98c79945] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.autocomplete-result[data-v-98c79945] {
+  display: flex;
+  align-items: center;
+  gap: var(--default-grid-baseline);
+  line-height: 1.2;
+  --auto-complete-result-avatar-size: var(--default-clickable-area);
+}
+.autocomplete-result__icon[data-v-98c79945] {
+  position: relative;
+  flex: 0 0 var(--default-clickable-area);
+  width: var(--default-clickable-area);
+  min-width: var(--default-clickable-area);
+  height: var(--default-clickable-area);
+  border-radius: var(--default-clickable-area);
+  background-color: var(--color-background-darker);
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+}
+.autocomplete-result__icon--with-avatar[data-v-98c79945] {
+  color: inherit;
+  background-size: cover;
+}
+.autocomplete-result__status[data-v-98c79945] {
+  --auto-complete-result-status-icon-size: clamp(14px, var(--auto-complete-result-avatar-size) * 0.4, 18px);
+  --auto-complete-result-status-icon-position: calc(var(--auto-complete-result-avatar-size) / 2 * (1 - 1 / sqrt(2)) - var(--auto-complete-result-status-icon-size) / 2);
+  box-sizing: border-box;
+  position: absolute;
+  right: var(--auto-complete-result-status-icon-position);
+  bottom: var(--auto-complete-result-status-icon-position);
+  height: var(--auto-complete-result-status-icon-size);
+  width: var(--auto-complete-result-status-icon-size);
+  border: 2px solid var(--color-main-background);
+  border-radius: 50%;
+  background-color: var(--color-main-background);
+  font-size: calc(var(--auto-complete-result-status-icon-size) / 1.2);
+  line-height: 1.2;
+  background-repeat: no-repeat;
+  background-size: var(--auto-complete-result-status-icon-size);
+  background-position: center;
+}
+.autocomplete-result__status--icon[data-v-98c79945] {
+  border: none;
+  background-color: transparent;
+}
+.autocomplete-result__content[data-v-98c79945] {
+  display: flex;
+  flex: 1 1 100%;
+  flex-direction: column;
+  justify-content: center;
+  min-width: 0;
+}
+.autocomplete-result__title[data-v-98c79945], .autocomplete-result__subline[data-v-98c79945] {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.autocomplete-result__subline[data-v-98c79945] {
+  color: var(--color-text-maxcontrast);
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-108d42c7] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.rich-contenteditable[data-v-108d42c7] {
+  position: relative;
+  width: auto;
+}
+.rich-contenteditable__label[data-v-108d42c7] {
+  position: absolute;
+  margin-inline: 14px 0;
+  max-width: fit-content;
+  inset-block-start: 11px;
+  inset-inline: 0;
+  color: var(--color-text-maxcontrast);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  pointer-events: none;
+  transition: height var(--animation-quick), inset-block-start var(--animation-quick), font-size var(--animation-quick), color var(--animation-quick), background-color var(--animation-quick) var(--animation-slow);
+}
+.rich-contenteditable__input:focus + .rich-contenteditable__label[data-v-108d42c7], .rich-contenteditable__input:not(.rich-contenteditable__input--empty) + .rich-contenteditable__label[data-v-108d42c7] {
+  inset-block-start: -10px;
+  line-height: 1.5;
+  font-size: 13px;
+  font-weight: 500;
+  border-radius: var(--default-grid-baseline) var(--default-grid-baseline) 0 0;
+  background-color: var(--color-main-background);
+  padding-inline: 5px;
+  margin-inline-start: 9px;
+  transition: height var(--animation-quick), inset-block-start var(--animation-quick), font-size var(--animation-quick), color var(--animation-quick);
+}
+.rich-contenteditable__input[data-v-108d42c7] {
+  overflow-y: auto;
+  width: auto;
+  margin: 0;
+  padding: 8px;
+  cursor: text;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--color-main-text);
+  border: 2px solid var(--color-border-maxcontrast);
+  border-radius: var(--border-radius-large);
+  outline: none;
+  background-color: var(--color-main-background);
+  font-family: var(--font-face);
+  font-size: inherit;
+  min-height: var(--default-clickable-area);
+  max-height: calc(var(--default-clickable-area) * 5.5);
+}
+.rich-contenteditable__input--has-label[data-v-108d42c7] {
+  margin-top: 10px;
+}
+.rich-contenteditable__input--empty[data-v-108d42c7]:focus:before, .rich-contenteditable__input--empty[data-v-108d42c7]:not(.rich-contenteditable__input--has-label):before {
+  content: attr(aria-placeholder);
+  color: var(--color-text-maxcontrast);
+  position: absolute;
+}
+.rich-contenteditable__input[contenteditable=false][data-v-108d42c7]:not(.rich-contenteditable__input--disabled) {
+  cursor: default;
+  background-color: transparent;
+  color: var(--color-main-text);
+  border-color: transparent;
+  opacity: 1;
+  border-radius: 0;
+}
+.rich-contenteditable__input--multiline[data-v-108d42c7] {
+  min-height: calc(var(--default-clickable-area) * 3);
+  max-height: none;
+}
+.rich-contenteditable__input--disabled[data-v-108d42c7] {
+  opacity: 0.5;
+  color: var(--color-text-maxcontrast);
+  border: 2px solid var(--color-background-darker);
+  border-radius: var(--border-radius);
+  background-color: var(--color-background-dark);
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+._material-design-icon_1o935_12 {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+._tribute-container_1o935_20 {
+  z-index: 9000;
+  overflow: auto;
+  position: absolute;
+  left: -10000px;
+  margin: var(--default-grid-baseline) 0;
+  padding: var(--default-grid-baseline);
+  color: var(--color-text-maxcontrast);
+  border-radius: var(--border-radius-element, var(--border-radius));
+  background: var(--color-main-background);
+  box-shadow: 0 1px 5px var(--color-box-shadow);
+}
+._tribute-container_1o935_20, ._tribute-container_1o935_20 * {
+  box-sizing: border-box;
+}
+._tribute-container_1o935_20 ul {
+  display: flex;
+  flex-direction: column;
+  gap: var(--default-grid-baseline);
+}
+._tribute-container_1o935_20 ._tribute-container__item_1o935_40 {
+  color: var(--color-text-maxcontrast);
+  border-radius: var(--border-radius-small, var(--border-radius));
+  padding: var(--default-grid-baseline);
+  cursor: pointer;
+  min-height: var(--clickable-area-small, auto);
+}
+._tribute-container_1o935_20 ._tribute-container__item_1o935_40.highlight {
+  color: var(--color-main-text);
+  background: var(--color-background-hover);
+}
+._tribute-container_1o935_20 ._tribute-container__item_1o935_40.highlight, ._tribute-container_1o935_20 ._tribute-container__item_1o935_40.highlight * {
+  cursor: pointer;
+}
+._tribute-container_1o935_20._tribute-container--focus-visible_1o935_54 .highlight._tribute-container__item_1o935_40 {
+  outline: 2px solid var(--color-main-text) !important;
+}
+._tribute-container-autocomplete_1o935_58 {
+  min-width: 250px;
+  max-width: 300px;
+  max-height: calc((var(--default-clickable-area) + 3 * var(--default-grid-baseline)) * 4.5 - 1.5 * var(--default-grid-baseline));
+}
+._tribute-container-emoji_1o935_64,
+._tribute-container-link_1o935_65 {
+  min-width: 200px;
+  max-width: 200px;
+  max-height: calc((24px + 3 * var(--default-grid-baseline)) * 5.5 - 1.5 * var(--default-grid-baseline));
+}
+._tribute-container-emoji_1o935_64 ._tribute-item_1o935_70,
+._tribute-container-link_1o935_65 ._tribute-item_1o935_70 {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+._tribute-container-link_1o935_65 {
+  min-width: 200px;
+  max-width: 300px;
+}
+._tribute-container-link_1o935_65 ._tribute-item_1o935_70 {
+  display: flex;
+  align-items: center;
+}
+._tribute-container-link_1o935_65 ._tribute-item__title_1o935_85 {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+._tribute-container-link_1o935_65 ._tribute-item__icon_1o935_90 {
+  margin: auto 0;
+  width: 20px;
+  height: 20px;
+  object-fit: contain;
+  padding-right: var(--default-grid-baseline);
+  filter: var(--background-invert-if-dark);
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-b293f5d9] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.widget-custom[data-v-b293f5d9] {
+  width: 100%;
+  margin: auto;
+  margin-bottom: calc(var(--default-grid-baseline, 4px) * 3);
+  margin-top: calc(var(--default-grid-baseline, 4px) * 3);
+  overflow: hidden;
+  border: 2px solid var(--color-border);
+  border-radius: var(--border-radius-large);
+  background-color: transparent;
+  display: flex;
+}
+.widget-custom.full-width[data-v-b293f5d9] {
+  width: var(--widget-full-width, 100%) !important;
+  left: calc((var(--widget-full-width, 100%) - 100%) / 2 * -1);
+  position: relative;
+}
+.widget-access[data-v-b293f5d9] {
+  width: 100%;
+  margin: auto;
+  margin-bottom: calc(var(--default-grid-baseline, 4px) * 3);
+  margin-top: calc(var(--default-grid-baseline, 4px) * 3);
+  overflow: hidden;
+  border: 2px solid var(--color-border);
+  border-radius: var(--border-radius-large);
+  background-color: transparent;
+  display: flex;
+  padding: calc(var(--default-grid-baseline, 4px) * 3);
+}
+.widget-default[data-v-b293f5d9] {
+  width: 100%;
+  margin: auto;
+  margin-bottom: calc(var(--default-grid-baseline, 4px) * 3);
+  margin-top: calc(var(--default-grid-baseline, 4px) * 3);
+  overflow: hidden;
+  border: 2px solid var(--color-border);
+  border-radius: var(--border-radius-large);
+  background-color: transparent;
+  display: flex;
+}
+.widget-default--compact[data-v-b293f5d9] {
+  flex-direction: column;
+}
+.widget-default--compact .widget-default--image[data-v-b293f5d9] {
+  width: 100%;
+  height: 150px;
+}
+.widget-default--compact .widget-default--details[data-v-b293f5d9] {
+  width: 100%;
+  padding-top: calc(var(--default-grid-baseline, 4px) * 2);
+  padding-bottom: calc(var(--default-grid-baseline, 4px) * 2);
+}
+.widget-default--compact .widget-default--description[data-v-b293f5d9] {
+  display: none;
+}
+.widget-default--image[data-v-b293f5d9] {
+  width: 40%;
+  background-position: center;
+  background-size: cover;
+  background-repeat: no-repeat;
+}
+.widget-default--name[data-v-b293f5d9] {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: bold;
+}
+.widget-default--details[data-v-b293f5d9] {
+  padding: calc(var(--default-grid-baseline, 4px) * 3);
+  width: 60%;
+}
+.widget-default--details p[data-v-b293f5d9] {
+  margin: 0;
+  padding: 0;
+}
+.widget-default--description[data-v-b293f5d9] {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  -webkit-box-orient: vertical;
+}
+.widget-default--link[data-v-b293f5d9] {
+  color: var(--color-text-maxcontrast);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.toggle-interactive[data-v-b293f5d9] {
+  position: relative;
+}
+.toggle-interactive .toggle-interactive--button[data-v-b293f5d9] {
+  position: absolute;
+  top: 50%;
+  z-index: 10000;
+  left: 50%;
+  transform: translateX(-50%) translateY(-50%);
+  opacity: 0;
+}
+.toggle-interactive:focus-within .toggle-interactive--button[data-v-b293f5d9], .toggle-interactive:hover .toggle-interactive--button[data-v-b293f5d9] {
+  opacity: 1;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-de9850e4] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-e54e09d6] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.provider-list[data-v-e54e09d6] {
+  width: 100%;
+  min-height: 400px;
+  padding: 0 16px 16px 16px;
+  display: flex;
+  flex-direction: column;
+}
+.provider-list--select[data-v-e54e09d6] {
+  width: 100%;
+}
+.provider-list--select .provider[data-v-e54e09d6] {
+  display: flex;
+  align-items: center;
+  height: 28px;
+  overflow: hidden;
+}
+.provider-list--select .provider .link-icon[data-v-e54e09d6] {
+  margin-right: 8px;
+}
+.provider-list--select .provider .provider-icon[data-v-e54e09d6] {
+  width: 20px;
+  height: 20px;
+  object-fit: contain;
+  margin-right: 8px;
+  filter: var(--background-invert-if-dark);
+}
+.provider-list--select .provider .option-text[data-v-e54e09d6] {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-3c1803b5] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.raw-link[data-v-3c1803b5] {
+  width: 100%;
+  min-height: 350px;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+  padding: 0 16px 16px 16px;
+}
+.raw-link .input-wrapper[data-v-3c1803b5] {
+  width: 100%;
+}
+.raw-link .reference-widget[data-v-3c1803b5] {
+  display: flex;
+}
+.raw-link--empty-content .provider-icon[data-v-3c1803b5] {
+  width: 150px;
+  height: 150px;
+  object-fit: contain;
+  filter: var(--background-invert-if-dark);
+}
+.raw-link--input[data-v-3c1803b5] {
+  width: 99%;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-8571023b] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.result[data-v-8571023b] {
+  display: flex;
+  align-items: center;
+  height: var(--default-clickable-area);
+  overflow: hidden;
+}
+.result--icon-class[data-v-8571023b], .result--image[data-v-8571023b] {
+  width: 40px;
+  min-width: 40px;
+  height: 40px;
+  object-fit: contain;
+}
+.result--icon-class.rounded[data-v-8571023b], .result--image.rounded[data-v-8571023b] {
+  border-radius: 50%;
+}
+.result--content[data-v-8571023b] {
+  display: flex;
+  flex-direction: column;
+  padding-left: 10px;
+  overflow: hidden;
+}
+.result--content--name[data-v-8571023b], .result--content--subline[data-v-8571023b] {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-05fef988] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.smart-picker-search[data-v-05fef988] {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  padding: 0 16px 16px 16px;
+}
+.smart-picker-search.with-empty-content[data-v-05fef988] {
+  min-height: 400px;
+}
+.smart-picker-search .provider-icon[data-v-05fef988] {
+  width: 150px;
+  height: 150px;
+  object-fit: contain;
+  filter: var(--background-invert-if-dark);
+}
+.smart-picker-search--select[data-v-05fef988] {
+  width: 100%;
+}
+.smart-picker-search--select .search-result[data-v-05fef988] {
+  width: 100%;
+}
+.smart-picker-search--select .group-name-icon[data-v-05fef988],
+.smart-picker-search--select .option-simple-icon[data-v-05fef988] {
+  width: 20px;
+  height: 20px;
+  margin: 0 20px 0 10px;
+}
+.smart-picker-search--select .custom-option[data-v-05fef988] {
+  height: var(--default-clickable-area);
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+}
+.smart-picker-search--select .option-text[data-v-05fef988] {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-f3f0de17] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.reference-picker[data-v-f3f0de17] {
+  display: flex;
+  overflow-y: auto;
+  width: 100%;
+}
+.reference-picker .custom-element-wrapper[data-v-f3f0de17] {
+  display: flex;
+  overflow-y: auto;
+  width: 100%;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.reference-picker-modal .modal-container {
+  display: flex !important;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-19d3f57d] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.reference-picker-modal--content[data-v-19d3f57d] {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  overflow-y: auto;
+}
+.reference-picker-modal--content .close-button[data-v-19d3f57d],
+.reference-picker-modal--content .back-button[data-v-19d3f57d] {
+  position: absolute;
+  top: 4px;
+}
+.reference-picker-modal--content .back-button[data-v-19d3f57d] {
+  left: 4px;
+}
+.reference-picker-modal--content .close-button[data-v-19d3f57d] {
+  right: 4px;
+}
+.reference-picker-modal--content > h2[data-v-19d3f57d] {
+  display: flex;
+  margin: 12px 0 20px 0;
+}
+.reference-picker-modal--content > h2 .icon[data-v-19d3f57d] {
+  margin-right: 8px;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-f5a7bd55] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.input-wrapper[data-v-f5a7bd55] {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  width: 100%;
+  max-width: 400px;
+}
+.input-wrapper .action-input__label[data-v-f5a7bd55] {
+  margin-right: 12px;
+}
+.input-wrapper[data-v-f5a7bd55]:disabled {
+  cursor: default;
+}
+.input-wrapper .hint[data-v-f5a7bd55] {
+  color: var(--color-text-maxcontrast);
+  margin-left: 8px;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-0974f50a] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.settings-section[data-v-0974f50a] {
+  display: block;
+  margin-bottom: auto;
+  padding: 30px;
+}
+.settings-section[data-v-0974f50a]:not(:last-child) {
+  border-bottom: 1px solid var(--color-border);
+}
+.settings-section--limit-width > *[data-v-0974f50a] {
+  max-width: 900px;
+}
+.settings-section__name[data-v-0974f50a] {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 20px;
+  font-weight: bold;
+  max-width: 900px;
+  margin-top: 0;
+}
+.settings-section__info[data-v-0974f50a] {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--default-clickable-area);
+  height: var(--default-clickable-area);
+  margin: calc((var(--default-clickable-area) - 16px) / 2 * -1);
+  margin-left: 0;
+  color: var(--color-text-maxcontrast);
+}
+.settings-section__info[data-v-0974f50a]:hover, .settings-section__info[data-v-0974f50a]:focus, .settings-section__info[data-v-0974f50a]:active {
+  color: var(--color-main-text);
+}
+.settings-section__desc[data-v-0974f50a] {
+  margin-top: -0.2em;
+  margin-bottom: 1em;
+  color: var(--color-text-maxcontrast);
+  max-width: 900px;
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-75b4f01b] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.select-group-error[data-v-75b4f01b] {
+  color: var(--color-error);
+  font-size: 13px;
+  padding-inline-start: var(--border-radius-large);
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-4b6abfac] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.textarea[data-v-4b6abfac] {
+  position: relative;
+  width: 100%;
+  border-radius: var(--border-radius-large);
+  margin-block-start: 6px;
+  resize: vertical;
+}
+.textarea__main-wrapper[data-v-4b6abfac] {
+  position: relative;
+}
+.textarea--disabled[data-v-4b6abfac] {
+  opacity: 0.7;
+  filter: saturate(0.7);
+}
+.textarea__input[data-v-4b6abfac] {
+  margin: 0;
+  padding-inline: 10px 6px;
+  width: 100%;
+  height: calc(var(--default-clickable-area) * 2);
+  font-size: var(--default-font-size);
+  text-overflow: ellipsis;
+  background-color: var(--color-main-background);
+  color: var(--color-main-text);
+  border: var(--border-width-input, 2px) solid var(--color-border-maxcontrast);
+  border-radius: var(--border-radius-large);
+  cursor: pointer;
+}
+.textarea__input[data-v-4b6abfac]:active:not([disabled]), .textarea__input[data-v-4b6abfac]:hover:not([disabled]), .textarea__input[data-v-4b6abfac]:focus:not([disabled]) {
+  border-width: var(--border-width-input-focused, 2px);
+  border-color: var(--color-main-text);
+  box-shadow: 0 0 0 2px var(--color-main-background) !important;
+}
+.textarea__input[data-v-4b6abfac]:not(:focus, .textarea__input--label-outside)::placeholder {
+  opacity: 0;
+}
+.textarea__input[data-v-4b6abfac]:focus {
+  cursor: text;
+}
+.textarea__input[data-v-4b6abfac]:disabled {
+  cursor: default;
+}
+.textarea__input[data-v-4b6abfac]:focus-visible {
+  box-shadow: unset !important;
+}
+.textarea__input--success[data-v-4b6abfac] {
+  border-color: var(--color-success) !important;
+}
+.textarea__input--success[data-v-4b6abfac]:focus-visible {
+  box-shadow: rgb(248, 250, 252) 0px 0px 0px 2px, var(--color-primary-element) 0px 0px 0px 4px, rgba(0, 0, 0, 0.05) 0px 1px 2px 0px;
+}
+.textarea__input--error[data-v-4b6abfac] {
+  border-color: var(--color-error) !important;
+}
+.textarea__input--error[data-v-4b6abfac]:focus-visible {
+  box-shadow: rgb(248, 250, 252) 0px 0px 0px 2px, var(--color-primary-element) 0px 0px 0px 4px, rgba(0, 0, 0, 0.05) 0px 1px 2px 0px;
+}
+.textarea__label[data-v-4b6abfac] {
+  position: absolute;
+  margin-inline: 12px 0;
+  max-width: fit-content;
+  inset-block-start: 11px;
+  inset-inline: 0;
+  color: var(--color-text-maxcontrast);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  pointer-events: none;
+  transition: height var(--animation-quick), inset-block-start var(--animation-quick), font-size var(--animation-quick), color var(--animation-quick), background-color var(--animation-quick) var(--animation-slow);
+}
+.textarea__input:focus + .textarea__label[data-v-4b6abfac], .textarea__input:not(:placeholder-shown) + .textarea__label[data-v-4b6abfac] {
+  inset-block-start: -10px;
+  line-height: 1.5;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--color-main-text);
+  background-color: var(--color-main-background);
+  padding-inline: 4px;
+  margin-inline-start: 8px;
+  transition: height var(--animation-quick), inset-block-start var(--animation-quick), font-size var(--animation-quick), color var(--animation-quick);
+}
+.textarea__helper-text-message[data-v-4b6abfac] {
+  padding-block: 4px;
+  display: flex;
+  align-items: center;
+}
+.textarea__helper-text-message__icon[data-v-4b6abfac] {
+  margin-inline-end: 8px;
+}
+.textarea__helper-text-message--error[data-v-4b6abfac] {
+  color: var(--color-error-text);
+}
+.textarea__helper-text-message--success[data-v-4b6abfac] {
+  color: var(--color-success-text);
+}/**
+ * SPDX-FileCopyrightText: 2019 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/**
+ * SPDX-FileCopyrightText: 2021 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+/*
+* Ensure proper alignment of the vue material icons
+*/
+.material-design-icon[data-v-b07a6c57] {
+  display: flex;
+  align-self: center;
+  justify-self: center;
+  align-items: center;
+  justify-content: center;
+}
+.user-bubble__wrapper[data-v-b07a6c57] {
+  display: inline-block;
+  vertical-align: middle;
+  min-width: 0;
+  max-width: 100%;
+}
+.user-bubble__content[data-v-b07a6c57] {
+  display: inline-flex;
+  max-width: 100%;
+  background-color: var(--color-background-dark);
+}
+.user-bubble__content--primary[data-v-b07a6c57] {
+  color: var(--color-primary-element-text);
+  background-color: var(--color-primary-element);
+}
+.user-bubble__content[data-v-b07a6c57] > :last-child {
+  padding-right: 8px;
+}
+.user-bubble__avatar[data-v-b07a6c57] {
+  align-self: center;
+}
+.user-bubble__name[data-v-b07a6c57] {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+.user-bubble__name[data-v-b07a6c57], .user-bubble__secondary[data-v-b07a6c57] {
+  padding: 0;
+  padding-left: 4px;
+}.viewer__image-editor[data-v-a2c8f486] {
+  position: absolute;
+  z-index: 10100;
+  top: calc(var(--header-height) * -1);
+  bottom: calc(var(--header-height) * -1);
+  left: 0;
+  width: 100%;
+  height: 100vh;
+}.SfxModal-Wrapper {
+  z-index: 10101 !important;
+}
+#SfxPopper {
+  z-index: 10102;
+  position: relative;
+}
+.viewer__image-editor *,
+.SfxModal-Wrapper *,
+.SfxPopper-wrapper * {
+  font-size: var(--default-font-size) !important;
+}
+.viewer__image-editor label,
+.viewer__image-editor button,
+.SfxModal-Wrapper label,
+.SfxModal-Wrapper button,
+.SfxPopper-wrapper label,
+.SfxPopper-wrapper button {
+  color: var(--color-main-text);
+}
+.viewer__image-editor label > span,
+.viewer__image-editor button > span,
+.SfxModal-Wrapper label > span,
+.SfxModal-Wrapper button > span,
+.SfxPopper-wrapper label > span,
+.SfxPopper-wrapper button > span {
+  font-size: var(--default-font-size) !important;
+}
+.viewer__image-editor button,
+.SfxModal-Wrapper button,
+.SfxPopper-wrapper button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
+  padding: 6px 12px;
+}
+.SfxInput-root {
+  height: auto !important;
+  padding: 0 !important;
+}
+.SfxInput-root .SfxInput-Base {
+  margin: 0 !important;
+}
+.SfxSelect-root {
+  padding: 8px !important;
+}
+.SfxButton-root {
+  min-height: 44px !important;
+  margin: 0 !important;
+  border: transparent !important;
+}
+.SfxButton-root[color=error] {
+  color: white !important;
+  background-color: var(--color-error) !important;
+}
+.SfxButton-root[color=error]:hover, .SfxButton-root[color=error]:focus {
+  border-color: white !important;
+  background-color: var(--color-error-hover) !important;
+}
+.SfxButton-root[color=primary] {
+  color: var(--color-primary-element-text) !important;
+  background-color: var(--color-primary-element) !important;
+}
+.SfxButton-root[color=primary]:hover, .SfxButton-root[color=primary]:focus {
+  background-color: var(--color-primary-element-hover) !important;
+}
+.SfxMenuItem-root {
+  height: 44px;
+  padding-left: 8px !important;
+}
+.SfxMenuItem-root > div {
+  margin-right: 0;
+  padding: 14px;
+  padding: 6px;
+  cursor: pointer;
+}
+.SfxMenuItem-root[value=jpeg] {
+  display: none;
+}
+.SfxModal-Container {
+  min-height: 300px;
+  padding: 22px;
+}
+.SfxModal-Container .SfxModal-root,
+.SfxModal-Container .SfxModalTitle-root {
+  flex: 1 1 100%;
+  justify-content: center;
+  color: var(--color-main-text);
+}
+.SfxModal-Container .SfxModalTitle-Icon {
+  margin-bottom: 22px !important;
+  background: none !important;
+}
+.SfxModal-Container .SfxModalTitle-Icon svg {
+  width: 64px;
+  height: 64px;
+  opacity: 0.4;
+  --color-primary: var(--color-main-text);
+  --color-error: var(--color-main-text);
+}
+.SfxModal-Container .SfxModalTitle-Close {
+  display: none !important;
+}
+.SfxModal-Container .SfxModalActions-root {
+  justify-content: space-evenly !important;
+}
+.FIE_topbar-center-options > button,
+.FIE_topbar-center-options > label {
+  margin-left: 6px !important;
+}
+.FIE_tabs {
+  padding: 6px !important;
+  overflow: hidden;
+  overflow-y: auto;
+}
+.FIE_tab {
+  width: 80px !important;
+  height: 80px !important;
+  padding: 8px;
+  border-radius: var(--border-radius-large) !important;
+}
+.FIE_tab svg {
+  width: 16px;
+  height: 16px;
+}
+.FIE_tab-label {
+  margin-top: 8px !important;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 100%;
+  white-space: nowrap;
+  display: block !important;
+}
+.FIE_tab:hover, .FIE_tab:focus {
+  background-color: var(--color-background-hover) !important;
+}
+.FIE_tab[aria-selected=true] {
+  color: var(--color-main-text);
+  background-color: var(--color-background-dark);
+  box-shadow: 0 0 0 2px var(--color-primary-element);
+}
+.FIE_tools-bar-wrapper {
+  max-height: max-content !important;
+}
+.FIE_tools-bar > div[class$=-tool-button], .FIE_tools-bar > div[class$=-tool] {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  height: 44px;
+  padding: 6px 16px;
+  border-radius: var(--border-radius-pill);
+}
+.FIE_crop-presets-opener-button {
+  min-width: 0 !important;
+  padding: 5px !important;
+  padding-left: 10px !important;
+  border: none !important;
+  background-color: transparent !important;
+}
+.FIE_topbar-history-buttons button,
+.FIE_topbar-close-button,
+.FIE_resize-ratio-locker {
+  border: none !important;
+  background-color: transparent !important;
+}
+.FIE_topbar-history-buttons button:hover, .FIE_topbar-history-buttons button:focus,
+.FIE_topbar-close-button:hover,
+.FIE_topbar-close-button:focus,
+.FIE_resize-ratio-locker:hover,
+.FIE_resize-ratio-locker:focus {
+  background-color: var(--color-background-hover) !important;
+}
+.FIE_topbar-history-buttons button svg,
+.FIE_topbar-close-button svg,
+.FIE_resize-ratio-locker svg {
+  width: 16px;
+  height: 16px;
+}
+.FIE_topbar-history-buttons button.FIE_topbar-reset-button::before {
+  content: attr(title);
+  font-weight: normal;
+}
+.FIE_topbar-history-buttons button.FIE_topbar-reset-button svg {
+  display: none;
+}
+.FIE_topbar-save-wrapper {
+  width: auto !important;
+}
+.FIE_topbar-save-button {
+  color: var(--color-primary-text) !important;
+  border: none !important;
+  background-color: var(--color-primary-element) !important;
+}
+.FIE_topbar-save-button:hover, .FIE_topbar-save-button:focus {
+  background-color: var(--color-primary-element-hover) !important;
+}
+.FIE_resize-tool-options .FIE_resize-width-option,
+.FIE_resize-tool-options .FIE_resize-height-option {
+  flex: 1 1;
+  min-width: 0;
+}
+.FIE_resize-ratio-locker {
+  margin-right: 8px !important;
+}
+.FIE_resize-ratio-locker svg {
+  width: 20px;
+  height: 20px;
+}
+.FIE_resize-ratio-locker svg path {
+  stroke-width: 1;
+  stroke: var(--color-main-text);
+  fill: var(--color-main-text);
+}
+.FIE_topbar-close-button svg path {
+  transform: scale(1.6);
+}
+.FIE_canvas-container {
+  background-color: var(--color-main-background) !important;
+}
+.FIE_spinner::after,
+.FIE_spinner-label {
+  display: none !important;
+}
+.FIE_spinner-wrapper {
+  background-color: transparent !important;
+}
+.FIE_spinner::before {
+  position: absolute;
+  z-index: 2;
+  top: 50%;
+  left: 50%;
+  width: 28px;
+  height: 28px;
+  margin: -16px 0 0 -16px;
+  content: "";
+  -webkit-transform-origin: center;
+  -ms-transform-origin: center;
+  transform-origin: center;
+  -webkit-animation: rotate 0.8s infinite linear;
+  animation: rotate 0.8s infinite linear;
+  border: 2px solid var(--color-loading-light);
+  border-top-color: var(--color-loading-dark);
+  border-radius: 100%;
+  filter: var(--background-invert-if-dark);
+}.image_container[data-v-d649c2f5] {
+  display: flex;
+  align-items: center;
+  height: 100%;
+  justify-content: center;
+}
+img[data-v-d649c2f5], video[data-v-d649c2f5] {
+  align-self: center;
+  justify-self: center;
+  background-color: #000;
+  transition: none !important;
+  touch-action: none;
+}
+img[data-v-d649c2f5]:hover, video[data-v-d649c2f5]:hover {
+  background-image: linear-gradient(45deg, #efefef 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #efefef 75%), linear-gradient(45deg, transparent 75%, #efefef 75%), linear-gradient(45deg, #efefef 25%, #fff 25%);
+  background-size: 16px 16px;
+  background-position: 0 0, 0 0, -8px -8px, 8px 8px;
+}
+img.loaded[data-v-d649c2f5], video.loaded[data-v-d649c2f5] {
+  background-color: #fff;
+}
+img.zoomed[data-v-d649c2f5], video.zoomed[data-v-d649c2f5] {
+  z-index: 10010;
+  cursor: move;
+}
+img.dragging[data-v-d649c2f5], video.dragging[data-v-d649c2f5] {
+  transition: none !important;
+  cursor: move;
+}
+.live-photo_play_button[data-v-d649c2f5] {
+  position: absolute;
+  top: 0;
+  margin: 16px !important;
+  display: flex;
+  align-items: center;
+  border: none;
+  gap: 4px;
+  border-radius: var(--border-radius);
+  padding: 4px 8px;
+  background-color: var(--color-main-background-blur);
+}@keyframes plyr-progress{to{background-position:25px 0;background-position:var(--plyr-progress-loading-size,25px) 0}}@keyframes plyr-popup{0%{opacity:.5;transform:translateY(10px)}to{opacity:1;transform:translateY(0)}}@keyframes plyr-fade-in{0%{opacity:0}to{opacity:1}}.plyr{-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased;align-items:center;direction:ltr;display:flex;flex-direction:column;font-family:inherit;font-family:var(--plyr-font-family,inherit);font-variant-numeric:tabular-nums;font-weight:400;font-weight:var(--plyr-font-weight-regular,400);line-height:1.7;line-height:var(--plyr-line-height,1.7);max-width:100%;min-width:200px;position:relative;text-shadow:none;transition:box-shadow .3s ease;z-index:0}.plyr audio,.plyr iframe,.plyr video{display:block;height:100%;width:100%}.plyr button{font:inherit;line-height:inherit;width:auto}.plyr:focus{outline:0}.plyr--full-ui{box-sizing:border-box}.plyr--full-ui *,.plyr--full-ui :after,.plyr--full-ui :before{box-sizing:inherit}.plyr--full-ui a,.plyr--full-ui button,.plyr--full-ui input,.plyr--full-ui label{touch-action:manipulation}.plyr__badge{background:#4a5464;background:var(--plyr-badge-background,#4a5464);border-radius:2px;border-radius:var(--plyr-badge-border-radius,2px);color:#fff;color:var(--plyr-badge-text-color,#fff);font-size:9px;font-size:var(--plyr-font-size-badge,9px);line-height:1;padding:3px 4px}.plyr--full-ui ::-webkit-media-text-track-container{display:none}.plyr__captions{animation:plyr-fade-in .3s ease;bottom:0;display:none;font-size:13px;font-size:var(--plyr-font-size-small,13px);left:0;padding:10px;padding:var(--plyr-control-spacing,10px);position:absolute;text-align:center;transition:transform .4s ease-in-out;width:100%}.plyr__captions span:empty{display:none}@media (min-width:480px){.plyr__captions{font-size:15px;font-size:var(--plyr-font-size-base,15px);padding:20px;padding:calc(var(--plyr-control-spacing, 10px)*2)}}@media (min-width:768px){.plyr__captions{font-size:18px;font-size:var(--plyr-font-size-large,18px)}}.plyr--captions-active .plyr__captions{display:block}.plyr:not(.plyr--hide-controls) .plyr__controls:not(:empty)~.plyr__captions{transform:translateY(-40px);transform:translateY(calc(var(--plyr-control-spacing, 10px)*-4))}.plyr__caption{background:#000c;background:var(--plyr-captions-background,#000c);border-radius:2px;-webkit-box-decoration-break:clone;box-decoration-break:clone;color:#fff;color:var(--plyr-captions-text-color,#fff);line-height:185%;padding:.2em .5em;white-space:pre-wrap}.plyr__caption div{display:inline}.plyr__control{background:#0000;border:0;border-radius:4px;border-radius:var(--plyr-control-radius,4px);color:inherit;cursor:pointer;flex-shrink:0;overflow:visible;padding:7px;padding:calc(var(--plyr-control-spacing, 10px)*.7);position:relative;transition:all .3s ease}.plyr__control svg{fill:currentColor;display:block;height:18px;height:var(--plyr-control-icon-size,18px);pointer-events:none;width:18px;width:var(--plyr-control-icon-size,18px)}.plyr__control:focus{outline:0}.plyr__control:focus-visible{outline:2px dashed #00b2ff;outline:2px dashed var(--plyr-focus-visible-color,var(--plyr-color-main,var(--plyr-color-main,#00b2ff)));outline-offset:2px}a.plyr__control{text-decoration:none}.plyr__control.plyr__control--pressed .icon--not-pressed,.plyr__control.plyr__control--pressed .label--not-pressed,.plyr__control:not(.plyr__control--pressed) .icon--pressed,.plyr__control:not(.plyr__control--pressed) .label--pressed,a.plyr__control:after,a.plyr__control:before{display:none}.plyr--full-ui ::-webkit-media-controls{display:none}.plyr__controls{align-items:center;display:flex;justify-content:flex-end;text-align:center}.plyr__controls .plyr__progress__container{flex:1;min-width:0}.plyr__controls .plyr__controls__item{margin-left:2.5px;margin-left:calc(var(--plyr-control-spacing, 10px)/4)}.plyr__controls .plyr__controls__item:first-child{margin-left:0;margin-right:auto}.plyr__controls .plyr__controls__item.plyr__progress__container{padding-left:2.5px;padding-left:calc(var(--plyr-control-spacing, 10px)/4)}.plyr__controls .plyr__controls__item.plyr__time{padding:0 5px;padding:0 calc(var(--plyr-control-spacing, 10px)/2)}.plyr__controls .plyr__controls__item.plyr__progress__container:first-child,.plyr__controls .plyr__controls__item.plyr__time+.plyr__time,.plyr__controls .plyr__controls__item.plyr__time:first-child{padding-left:0}.plyr [data-plyr=airplay],.plyr [data-plyr=captions],.plyr [data-plyr=fullscreen],.plyr [data-plyr=pip],.plyr__controls:empty{display:none}.plyr--airplay-supported [data-plyr=airplay],.plyr--captions-enabled [data-plyr=captions],.plyr--fullscreen-enabled [data-plyr=fullscreen],.plyr--pip-supported [data-plyr=pip]{display:inline-block}.plyr__menu{display:flex;position:relative}.plyr__menu .plyr__control svg{transition:transform .3s ease}.plyr__menu .plyr__control[aria-expanded=true] svg{transform:rotate(90deg)}.plyr__menu .plyr__control[aria-expanded=true] .plyr__tooltip{display:none}.plyr__menu__container{animation:plyr-popup .2s ease;background:#ffffffe6;background:var(--plyr-menu-background,#ffffffe6);border-radius:8px;border-radius:var(--plyr-menu-radius,8px);bottom:100%;box-shadow:0 1px 2px #00000026;box-shadow:var(--plyr-menu-shadow,0 1px 2px #00000026);color:#4a5464;color:var(--plyr-menu-color,#4a5464);font-size:15px;font-size:var(--plyr-font-size-base,15px);margin-bottom:10px;position:absolute;right:-3px;text-align:left;white-space:nowrap;z-index:3}.plyr__menu__container>div{overflow:hidden;transition:height .35s cubic-bezier(.4,0,.2,1),width .35s cubic-bezier(.4,0,.2,1)}.plyr__menu__container:after{border:4px solid #0000;border-top-color:#ffffffe6;border:var(--plyr-menu-arrow-size,4px) solid #0000;border-top-color:var(--plyr-menu-background,#ffffffe6);content:"";height:0;position:absolute;right:14px;right:calc(var(--plyr-control-icon-size, 18px)/2 + var(--plyr-control-spacing, 10px)*.7 - var(--plyr-menu-arrow-size, 4px)/2);top:100%;width:0}.plyr__menu__container [role=menu]{padding:7px;padding:calc(var(--plyr-control-spacing, 10px)*.7)}.plyr__menu__container [role=menuitem],.plyr__menu__container [role=menuitemradio]{margin-top:2px}.plyr__menu__container [role=menuitem]:first-child,.plyr__menu__container [role=menuitemradio]:first-child{margin-top:0}.plyr__menu__container .plyr__control{align-items:center;color:#4a5464;color:var(--plyr-menu-color,#4a5464);display:flex;font-size:13px;font-size:var(--plyr-font-size-menu,var(--plyr-font-size-small,13px));padding:4.66667px 10.5px;padding:calc(var(--plyr-control-spacing, 10px)*.7/1.5) calc(var(--plyr-control-spacing, 10px)*.7*1.5);-webkit-user-select:none;user-select:none;width:100%}.plyr__menu__container .plyr__control>span{align-items:inherit;display:flex;width:100%}.plyr__menu__container .plyr__control:after{border:4px solid #0000;border:var(--plyr-menu-item-arrow-size,4px) solid #0000;content:"";position:absolute;top:50%;transform:translateY(-50%)}.plyr__menu__container .plyr__control--forward{padding-right:28px;padding-right:calc(var(--plyr-control-spacing, 10px)*.7*4)}.plyr__menu__container .plyr__control--forward:after{border-left-color:#728197;border-left-color:var(--plyr-menu-arrow-color,#728197);right:6.5px;right:calc(var(--plyr-control-spacing, 10px)*.7*1.5 - var(--plyr-menu-item-arrow-size, 4px))}.plyr__menu__container .plyr__control--forward:focus-visible:after,.plyr__menu__container .plyr__control--forward:hover:after{border-left-color:initial}.plyr__menu__container .plyr__control--back{font-weight:400;font-weight:var(--plyr-font-weight-regular,400);margin:7px;margin:calc(var(--plyr-control-spacing, 10px)*.7);margin-bottom:3.5px;margin-bottom:calc(var(--plyr-control-spacing, 10px)*.7/2);padding-left:28px;padding-left:calc(var(--plyr-control-spacing, 10px)*.7*4);position:relative;width:calc(100% - 14px);width:calc(100% - var(--plyr-control-spacing, 10px)*.7*2)}.plyr__menu__container .plyr__control--back:after{border-right-color:#728197;border-right-color:var(--plyr-menu-arrow-color,#728197);left:6.5px;left:calc(var(--plyr-control-spacing, 10px)*.7*1.5 - var(--plyr-menu-item-arrow-size, 4px))}.plyr__menu__container .plyr__control--back:before{background:#dcdfe5;background:var(--plyr-menu-back-border-color,#dcdfe5);box-shadow:0 1px 0 #fff;box-shadow:0 1px 0 var(--plyr-menu-back-border-shadow-color,#fff);content:"";height:1px;left:0;margin-top:3.5px;margin-top:calc(var(--plyr-control-spacing, 10px)*.7/2);overflow:hidden;position:absolute;right:0;top:100%}.plyr__menu__container .plyr__control--back:focus-visible:after,.plyr__menu__container .plyr__control--back:hover:after{border-right-color:initial}.plyr__menu__container .plyr__control[role=menuitemradio]{padding-left:7px;padding-left:calc(var(--plyr-control-spacing, 10px)*.7)}.plyr__menu__container .plyr__control[role=menuitemradio]:after,.plyr__menu__container .plyr__control[role=menuitemradio]:before{border-radius:100%}.plyr__menu__container .plyr__control[role=menuitemradio]:before{background:#0000001a;content:"";display:block;flex-shrink:0;height:16px;margin-right:10px;margin-right:var(--plyr-control-spacing,10px);transition:all .3s ease;width:16px}.plyr__menu__container .plyr__control[role=menuitemradio]:after{background:#fff;border:0;height:6px;left:12px;opacity:0;top:50%;transform:translateY(-50%) scale(0);transition:transform .3s ease,opacity .3s ease;width:6px}.plyr__menu__container .plyr__control[role=menuitemradio][aria-checked=true]:before{background:#00b2ff;background:var(--plyr-control-toggle-checked-background,var(--plyr-color-main,var(--plyr-color-main,#00b2ff)))}.plyr__menu__container .plyr__control[role=menuitemradio][aria-checked=true]:after{opacity:1;transform:translateY(-50%) scale(1)}.plyr__menu__container .plyr__control[role=menuitemradio]:focus-visible:before,.plyr__menu__container .plyr__control[role=menuitemradio]:hover:before{background:#23282f1a}.plyr__menu__container .plyr__menu__value{align-items:center;display:flex;margin-left:auto;margin-right:-5px;margin-right:calc(var(--plyr-control-spacing, 10px)*.7*-1 - -2px);overflow:hidden;padding-left:24.5px;padding-left:calc(var(--plyr-control-spacing, 10px)*.7*3.5);pointer-events:none}.plyr--full-ui input[type=range]{-webkit-appearance:none;appearance:none;background:#0000;border:0;border-radius:26px;border-radius:calc(var(--plyr-range-thumb-height, 13px)*2);color:#00b2ff;color:var(--plyr-range-fill-background,var(--plyr-color-main,var(--plyr-color-main,#00b2ff)));display:block;height:19px;height:calc(var(--plyr-range-thumb-active-shadow-width, 3px)*2 + var(--plyr-range-thumb-height, 13px));margin:0;min-width:0;padding:0;transition:box-shadow .3s ease;width:100%}.plyr--full-ui input[type=range]::-webkit-slider-runnable-track{background:#0000;background-image:linear-gradient(90deg,currentColor 0,#0000 0);background-image:linear-gradient(to right,currentColor var(--value,0),#0000 var(--value,0));border:0;border-radius:2.5px;border-radius:calc(var(--plyr-range-track-height, 5px)/2);height:5px;height:var(--plyr-range-track-height,5px);-webkit-transition:box-shadow .3s ease;transition:box-shadow .3s ease;-webkit-user-select:none;user-select:none}.plyr--full-ui input[type=range]::-webkit-slider-thumb{-webkit-appearance:none;appearance:none;background:#fff;background:var(--plyr-range-thumb-background,#fff);border:0;border-radius:100%;box-shadow:0 1px 1px #23282f26,0 0 0 1px #23282f33;box-shadow:var(--plyr-range-thumb-shadow,0 1px 1px #23282f26,0 0 0 1px #23282f33);height:13px;height:var(--plyr-range-thumb-height,13px);margin-top:-4px;margin-top:calc((var(--plyr-range-thumb-height, 13px) - var(--plyr-range-track-height, 5px))/2*-1);position:relative;-webkit-transition:all .2s ease;transition:all .2s ease;width:13px;width:var(--plyr-range-thumb-height,13px)}.plyr--full-ui input[type=range]::-moz-range-track{background:#0000;border:0;border-radius:2.5px;border-radius:calc(var(--plyr-range-track-height, 5px)/2);height:5px;height:var(--plyr-range-track-height,5px);-moz-transition:box-shadow .3s ease;transition:box-shadow .3s ease;user-select:none}.plyr--full-ui input[type=range]::-moz-range-thumb{background:#fff;background:var(--plyr-range-thumb-background,#fff);border:0;border-radius:100%;box-shadow:0 1px 1px #23282f26,0 0 0 1px #23282f33;box-shadow:var(--plyr-range-thumb-shadow,0 1px 1px #23282f26,0 0 0 1px #23282f33);height:13px;height:var(--plyr-range-thumb-height,13px);position:relative;-moz-transition:all .2s ease;transition:all .2s ease;width:13px;width:var(--plyr-range-thumb-height,13px)}.plyr--full-ui input[type=range]::-moz-range-progress{background:currentColor;border-radius:2.5px;border-radius:calc(var(--plyr-range-track-height, 5px)/2);height:5px;height:var(--plyr-range-track-height,5px)}.plyr--full-ui input[type=range]::-ms-track{color:#0000}.plyr--full-ui input[type=range]::-ms-fill-upper,.plyr--full-ui input[type=range]::-ms-track{background:#0000;border:0;border-radius:2.5px;border-radius:calc(var(--plyr-range-track-height, 5px)/2);height:5px;height:var(--plyr-range-track-height,5px);-ms-transition:box-shadow .3s ease;transition:box-shadow .3s ease;user-select:none}.plyr--full-ui input[type=range]::-ms-fill-lower{background:#0000;background:currentColor;border:0;border-radius:2.5px;border-radius:calc(var(--plyr-range-track-height, 5px)/2);height:5px;height:var(--plyr-range-track-height,5px);-ms-transition:box-shadow .3s ease;transition:box-shadow .3s ease;user-select:none}.plyr--full-ui input[type=range]::-ms-thumb{background:#fff;background:var(--plyr-range-thumb-background,#fff);border:0;border-radius:100%;box-shadow:0 1px 1px #23282f26,0 0 0 1px #23282f33;box-shadow:var(--plyr-range-thumb-shadow,0 1px 1px #23282f26,0 0 0 1px #23282f33);height:13px;height:var(--plyr-range-thumb-height,13px);margin-top:0;position:relative;-ms-transition:all .2s ease;transition:all .2s ease;width:13px;width:var(--plyr-range-thumb-height,13px)}.plyr--full-ui input[type=range]::-ms-tooltip{display:none}.plyr--full-ui input[type=range]::-moz-focus-outer{border:0}.plyr--full-ui input[type=range]:focus{outline:0}.plyr--full-ui input[type=range]:focus-visible::-webkit-slider-runnable-track{outline:2px dashed #00b2ff;outline:2px dashed var(--plyr-focus-visible-color,var(--plyr-color-main,var(--plyr-color-main,#00b2ff)));outline-offset:2px}.plyr--full-ui input[type=range]:focus-visible::-moz-range-track{outline:2px dashed #00b2ff;outline:2px dashed var(--plyr-focus-visible-color,var(--plyr-color-main,var(--plyr-color-main,#00b2ff)));outline-offset:2px}.plyr--full-ui input[type=range]:focus-visible::-ms-track{outline:2px dashed #00b2ff;outline:2px dashed var(--plyr-focus-visible-color,var(--plyr-color-main,var(--plyr-color-main,#00b2ff)));outline-offset:2px}.plyr__poster{background-color:#000;background-color:var(--plyr-video-background,var(--plyr-video-background,#000));background-position:50% 50%;background-repeat:no-repeat;background-size:contain;height:100%;left:0;opacity:0;position:absolute;top:0;transition:opacity .2s ease;width:100%;z-index:1}.plyr--stopped.plyr__poster-enabled .plyr__poster{opacity:1}.plyr--youtube.plyr--paused.plyr__poster-enabled:not(.plyr--stopped) .plyr__poster{display:none}.plyr__time{font-size:13px;font-size:var(--plyr-font-size-time,var(--plyr-font-size-small,13px))}.plyr__time+.plyr__time:before{content:"⁄";margin-right:10px;margin-right:var(--plyr-control-spacing,10px)}@media (max-width:767px){.plyr__time+.plyr__time{display:none}}.plyr__tooltip{background:#fff;background:var(--plyr-tooltip-background,#fff);border-radius:5px;border-radius:var(--plyr-tooltip-radius,5px);bottom:100%;box-shadow:0 1px 2px #00000026;box-shadow:var(--plyr-tooltip-shadow,0 1px 2px #00000026);color:#4a5464;color:var(--plyr-tooltip-color,#4a5464);font-size:13px;font-size:var(--plyr-font-size-small,13px);font-weight:400;font-weight:var(--plyr-font-weight-regular,400);left:50%;line-height:1.3;margin-bottom:10px;margin-bottom:calc(var(--plyr-control-spacing, 10px)/2*2);opacity:0;padding:5px 7.5px;padding:calc(var(--plyr-control-spacing, 10px)/2) calc(var(--plyr-control-spacing, 10px)/2*1.5);pointer-events:none;position:absolute;transform:translate(-50%,10px) scale(.8);transform-origin:50% 100%;transition:transform .2s ease .1s,opacity .2s ease .1s;white-space:nowrap;z-index:2}.plyr__tooltip:before{border-left:4px solid #0000;border-left:var(--plyr-tooltip-arrow-size,4px) solid #0000;border-right:4px solid #0000;border-right:var(--plyr-tooltip-arrow-size,4px) solid #0000;border-top:4px solid #fff;border-top:var(--plyr-tooltip-arrow-size,4px) solid var(--plyr-tooltip-background,#fff);bottom:-4px;bottom:calc(var(--plyr-tooltip-arrow-size, 4px)*-1);content:"";height:0;left:50%;position:absolute;transform:translateX(-50%);width:0;z-index:2}.plyr .plyr__control:focus-visible .plyr__tooltip,.plyr .plyr__control:hover .plyr__tooltip,.plyr__tooltip--visible{opacity:1;transform:translate(-50%) scale(1)}.plyr .plyr__control:hover .plyr__tooltip{z-index:3}.plyr__controls>.plyr__control:first-child .plyr__tooltip,.plyr__controls>.plyr__control:first-child+.plyr__control .plyr__tooltip{left:0;transform:translateY(10px) scale(.8);transform-origin:0 100%}.plyr__controls>.plyr__control:first-child .plyr__tooltip:before,.plyr__controls>.plyr__control:first-child+.plyr__control .plyr__tooltip:before{left:16px;left:calc(var(--plyr-control-icon-size, 18px)/2 + var(--plyr-control-spacing, 10px)*.7)}.plyr__controls>.plyr__control:last-child .plyr__tooltip{left:auto;right:0;transform:translateY(10px) scale(.8);transform-origin:100% 100%}.plyr__controls>.plyr__control:last-child .plyr__tooltip:before{left:auto;right:16px;right:calc(var(--plyr-control-icon-size, 18px)/2 + var(--plyr-control-spacing, 10px)*.7);transform:translateX(50%)}.plyr__controls>.plyr__control:first-child .plyr__tooltip--visible,.plyr__controls>.plyr__control:first-child+.plyr__control .plyr__tooltip--visible,.plyr__controls>.plyr__control:first-child+.plyr__control:focus-visible .plyr__tooltip,.plyr__controls>.plyr__control:first-child+.plyr__control:hover .plyr__tooltip,.plyr__controls>.plyr__control:first-child:focus-visible .plyr__tooltip,.plyr__controls>.plyr__control:first-child:hover .plyr__tooltip,.plyr__controls>.plyr__control:last-child .plyr__tooltip--visible,.plyr__controls>.plyr__control:last-child:focus-visible .plyr__tooltip,.plyr__controls>.plyr__control:last-child:hover .plyr__tooltip{transform:translate(0) scale(1)}.plyr__progress{left:6.5px;left:calc(var(--plyr-range-thumb-height, 13px)*.5);margin-right:13px;margin-right:var(--plyr-range-thumb-height,13px);position:relative}.plyr__progress input[type=range],.plyr__progress__buffer{margin-left:-6.5px;margin-left:calc(var(--plyr-range-thumb-height, 13px)*-.5);margin-right:-6.5px;margin-right:calc(var(--plyr-range-thumb-height, 13px)*-.5);width:calc(100% + 13px);width:calc(100% + var(--plyr-range-thumb-height, 13px))}.plyr__progress input[type=range]{position:relative;z-index:2}.plyr__progress .plyr__tooltip{left:0;max-width:120px;overflow-wrap:break-word}.plyr__progress__buffer{-webkit-appearance:none;background:#0000;border:0;border-radius:100px;height:5px;height:var(--plyr-range-track-height,5px);left:0;margin-top:-2.5px;margin-top:calc((var(--plyr-range-track-height, 5px)/2)*-1);padding:0;position:absolute;top:50%}.plyr__progress__buffer::-webkit-progress-bar{background:#0000}.plyr__progress__buffer::-webkit-progress-value{background:currentColor;border-radius:100px;min-width:5px;min-width:var(--plyr-range-track-height,5px);-webkit-transition:width .2s ease;transition:width .2s ease}.plyr__progress__buffer::-moz-progress-bar{background:currentColor;border-radius:100px;min-width:5px;min-width:var(--plyr-range-track-height,5px);-moz-transition:width .2s ease;transition:width .2s ease}.plyr__progress__buffer::-ms-fill{border-radius:100px;-ms-transition:width .2s ease;transition:width .2s ease}.plyr--loading .plyr__progress__buffer{animation:plyr-progress 1s linear infinite;background-image:linear-gradient(-45deg,#23282f99 25%,#0000 0,#0000 50%,#23282f99 0,#23282f99 75%,#0000 0,#0000);background-image:linear-gradient(-45deg,var(--plyr-progress-loading-background,#23282f99) 25%,#0000 25%,#0000 50%,var(--plyr-progress-loading-background,#23282f99) 50%,var(--plyr-progress-loading-background,#23282f99) 75%,#0000 75%,#0000);background-repeat:repeat-x;background-size:25px 25px;background-size:var(--plyr-progress-loading-size,25px) var(--plyr-progress-loading-size,25px);color:#0000}.plyr--video.plyr--loading .plyr__progress__buffer{background-color:#ffffff40;background-color:var(--plyr-video-progress-buffered-background,#ffffff40)}.plyr--audio.plyr--loading .plyr__progress__buffer{background-color:#c1c8d199;background-color:var(--plyr-audio-progress-buffered-background,#c1c8d199)}.plyr__progress__marker{background-color:#fff;background-color:var(--plyr-progress-marker-background,#fff);border-radius:1px;height:5px;height:var(--plyr-range-track-height,5px);position:absolute;top:50%;transform:translate(-50%,-50%);width:3px;width:var(--plyr-progress-marker-width,3px);z-index:3}.plyr__volume{align-items:center;display:flex;position:relative}.plyr__volume input[type=range]{margin-left:5px;margin-left:calc(var(--plyr-control-spacing, 10px)/2);margin-right:5px;margin-right:calc(var(--plyr-control-spacing, 10px)/2);max-width:90px;min-width:60px;position:relative;z-index:2}.plyr--audio{display:block}.plyr--audio .plyr__controls{background:#fff;background:var(--plyr-audio-controls-background,#fff);border-radius:inherit;color:#4a5464;color:var(--plyr-audio-control-color,#4a5464);padding:10px;padding:var(--plyr-control-spacing,10px)}.plyr--audio .plyr__control:focus-visible,.plyr--audio .plyr__control:hover,.plyr--audio .plyr__control[aria-expanded=true]{background:#00b2ff;background:var(--plyr-audio-control-background-hover,var(--plyr-color-main,var(--plyr-color-main,#00b2ff)));color:#fff;color:var(--plyr-audio-control-color-hover,#fff)}.plyr--full-ui.plyr--audio input[type=range]::-webkit-slider-runnable-track{background-color:#c1c8d199;background-color:var(--plyr-audio-range-track-background,var(--plyr-audio-progress-buffered-background,#c1c8d199))}.plyr--full-ui.plyr--audio input[type=range]::-moz-range-track{background-color:#c1c8d199;background-color:var(--plyr-audio-range-track-background,var(--plyr-audio-progress-buffered-background,#c1c8d199))}.plyr--full-ui.plyr--audio input[type=range]::-ms-track{background-color:#c1c8d199;background-color:var(--plyr-audio-range-track-background,var(--plyr-audio-progress-buffered-background,#c1c8d199))}.plyr--full-ui.plyr--audio input[type=range]:active::-webkit-slider-thumb{box-shadow:0 1px 1px #23282f26,0 0 0 1px #23282f33,0 0 0 3px #23282f1a;box-shadow:var(--plyr-range-thumb-shadow,0 1px 1px #23282f26,0 0 0 1px #23282f33),0 0 0 var(--plyr-range-thumb-active-shadow-width,3px) var(--plyr-audio-range-thumb-active-shadow-color,#23282f1a)}.plyr--full-ui.plyr--audio input[type=range]:active::-moz-range-thumb{box-shadow:0 1px 1px #23282f26,0 0 0 1px #23282f33,0 0 0 3px #23282f1a;box-shadow:var(--plyr-range-thumb-shadow,0 1px 1px #23282f26,0 0 0 1px #23282f33),0 0 0 var(--plyr-range-thumb-active-shadow-width,3px) var(--plyr-audio-range-thumb-active-shadow-color,#23282f1a)}.plyr--full-ui.plyr--audio input[type=range]:active::-ms-thumb{box-shadow:0 1px 1px #23282f26,0 0 0 1px #23282f33,0 0 0 3px #23282f1a;box-shadow:var(--plyr-range-thumb-shadow,0 1px 1px #23282f26,0 0 0 1px #23282f33),0 0 0 var(--plyr-range-thumb-active-shadow-width,3px) var(--plyr-audio-range-thumb-active-shadow-color,#23282f1a)}.plyr--audio .plyr__progress__buffer{color:#c1c8d199;color:var(--plyr-audio-progress-buffered-background,#c1c8d199)}.plyr--video{overflow:hidden}.plyr--video.plyr--menu-open{overflow:visible}.plyr__video-wrapper{background:#000;background:var(--plyr-video-background,var(--plyr-video-background,#000));border-radius:inherit;height:100%;margin:auto;overflow:hidden;position:relative;width:100%}.plyr__video-embed,.plyr__video-wrapper--fixed-ratio{aspect-ratio:16/9}@supports not (aspect-ratio:16/9){.plyr__video-embed,.plyr__video-wrapper--fixed-ratio{height:0;padding-bottom:56.25%;position:relative}}.plyr__video-embed iframe,.plyr__video-wrapper--fixed-ratio video{border:0;height:100%;left:0;position:absolute;top:0;width:100%}.plyr--full-ui .plyr__video-embed>.plyr__video-embed__container{padding-bottom:240%;position:relative;transform:translateY(-38.28125%)}.plyr--video .plyr__controls{background:linear-gradient(#0000,#000000bf);background:var(--plyr-video-controls-background,linear-gradient(#0000,#000000bf));border-bottom-left-radius:inherit;border-bottom-right-radius:inherit;bottom:0;color:#fff;color:var(--plyr-video-control-color,#fff);left:0;padding:5px;padding:calc(var(--plyr-control-spacing, 10px)/2);padding-top:20px;padding-top:calc(var(--plyr-control-spacing, 10px)*2);position:absolute;right:0;transition:opacity .4s ease-in-out,transform .4s ease-in-out;z-index:3}@media (min-width:480px){.plyr--video .plyr__controls{padding:10px;padding:var(--plyr-control-spacing,10px);padding-top:35px;padding-top:calc(var(--plyr-control-spacing, 10px)*3.5)}}.plyr--video.plyr--hide-controls .plyr__controls{opacity:0;pointer-events:none;transform:translateY(100%)}.plyr--video .plyr__control:focus-visible,.plyr--video .plyr__control:hover,.plyr--video .plyr__control[aria-expanded=true]{background:#00b2ff;background:var(--plyr-video-control-background-hover,var(--plyr-color-main,var(--plyr-color-main,#00b2ff)));color:#fff;color:var(--plyr-video-control-color-hover,#fff)}.plyr__control--overlaid{background:#00b2ff;background:var(--plyr-video-control-background-hover,var(--plyr-color-main,var(--plyr-color-main,#00b2ff)));border:0;border-radius:100%;color:#fff;color:var(--plyr-video-control-color,#fff);display:none;left:50%;opacity:.9;padding:15px;padding:calc(var(--plyr-control-spacing, 10px)*1.5);position:absolute;top:50%;transform:translate(-50%,-50%);transition:.3s;z-index:2}.plyr__control--overlaid svg{left:2px;position:relative}.plyr__control--overlaid:focus,.plyr__control--overlaid:hover{opacity:1}.plyr--playing .plyr__control--overlaid{opacity:0;visibility:hidden}.plyr--full-ui.plyr--video .plyr__control--overlaid{display:block}.plyr--full-ui.plyr--video input[type=range]::-webkit-slider-runnable-track{background-color:#ffffff40;background-color:var(--plyr-video-range-track-background,var(--plyr-video-progress-buffered-background,#ffffff40))}.plyr--full-ui.plyr--video input[type=range]::-moz-range-track{background-color:#ffffff40;background-color:var(--plyr-video-range-track-background,var(--plyr-video-progress-buffered-background,#ffffff40))}.plyr--full-ui.plyr--video input[type=range]::-ms-track{background-color:#ffffff40;background-color:var(--plyr-video-range-track-background,var(--plyr-video-progress-buffered-background,#ffffff40))}.plyr--full-ui.plyr--video input[type=range]:active::-webkit-slider-thumb{box-shadow:0 1px 1px #23282f26,0 0 0 1px #23282f33,0 0 0 3px #ffffff80;box-shadow:var(--plyr-range-thumb-shadow,0 1px 1px #23282f26,0 0 0 1px #23282f33),0 0 0 var(--plyr-range-thumb-active-shadow-width,3px) var(--plyr-audio-range-thumb-active-shadow-color,#ffffff80)}.plyr--full-ui.plyr--video input[type=range]:active::-moz-range-thumb{box-shadow:0 1px 1px #23282f26,0 0 0 1px #23282f33,0 0 0 3px #ffffff80;box-shadow:var(--plyr-range-thumb-shadow,0 1px 1px #23282f26,0 0 0 1px #23282f33),0 0 0 var(--plyr-range-thumb-active-shadow-width,3px) var(--plyr-audio-range-thumb-active-shadow-color,#ffffff80)}.plyr--full-ui.plyr--video input[type=range]:active::-ms-thumb{box-shadow:0 1px 1px #23282f26,0 0 0 1px #23282f33,0 0 0 3px #ffffff80;box-shadow:var(--plyr-range-thumb-shadow,0 1px 1px #23282f26,0 0 0 1px #23282f33),0 0 0 var(--plyr-range-thumb-active-shadow-width,3px) var(--plyr-audio-range-thumb-active-shadow-color,#ffffff80)}.plyr--video .plyr__progress__buffer{color:#ffffff40;color:var(--plyr-video-progress-buffered-background,#ffffff40)}.plyr:fullscreen{background:#000;border-radius:0!important;height:100%;margin:0;width:100%}.plyr:fullscreen video{height:100%}.plyr:fullscreen .plyr__control .icon--exit-fullscreen{display:block}.plyr:fullscreen .plyr__control .icon--exit-fullscreen+svg{display:none}.plyr:fullscreen.plyr--hide-controls{cursor:none}@media (min-width:1024px){.plyr:fullscreen .plyr__captions{font-size:21px;font-size:var(--plyr-font-size-xlarge,21px)}}.plyr--fullscreen-fallback{background:#000;border-radius:0!important;bottom:0;height:100%;left:0;margin:0;position:fixed;right:0;top:0;width:100%;z-index:10000000}.plyr--fullscreen-fallback video{height:100%}.plyr--fullscreen-fallback .plyr__control .icon--exit-fullscreen{display:block}.plyr--fullscreen-fallback .plyr__control .icon--exit-fullscreen+svg{display:none}.plyr--fullscreen-fallback.plyr--hide-controls{cursor:none}@media (min-width:1024px){.plyr--fullscreen-fallback .plyr__captions{font-size:21px;font-size:var(--plyr-font-size-xlarge,21px)}}.plyr__ads{border-radius:inherit;bottom:0;cursor:pointer;left:0;overflow:hidden;position:absolute;right:0;top:0;z-index:-1}.plyr__ads>div,.plyr__ads>div iframe{height:100%;position:absolute;width:100%}.plyr__ads:after{background:#23282f;border-radius:2px;bottom:10px;bottom:var(--plyr-control-spacing,10px);color:#fff;content:attr(data-badge-text);font-size:11px;padding:2px 6px;pointer-events:none;position:absolute;right:10px;right:var(--plyr-control-spacing,10px);z-index:3}.plyr__ads:empty:after{display:none}.plyr__cues{background:currentColor;display:block;height:5px;height:var(--plyr-range-track-height,5px);left:0;opacity:.8;position:absolute;top:50%;transform:translateY(-50%);width:3px;z-index:3}.plyr__preview-thumb{background-color:#fff;background-color:var(--plyr-tooltip-background,#fff);border-radius:8px;border-radius:var(--plyr-menu-radius,8px);bottom:100%;box-shadow:0 1px 2px #00000026;box-shadow:var(--plyr-tooltip-shadow,0 1px 2px #00000026);margin-bottom:10px;margin-bottom:calc(var(--plyr-control-spacing, 10px)/2*2);opacity:0;padding:3px;pointer-events:none;position:absolute;transform:translateY(10px) scale(.8);transform-origin:50% 100%;transition:transform .2s ease .1s,opacity .2s ease .1s;z-index:2}.plyr__preview-thumb--is-shown{opacity:1;transform:translate(0) scale(1)}.plyr__preview-thumb:before{border-left:4px solid #0000;border-left:var(--plyr-tooltip-arrow-size,4px) solid #0000;border-right:4px solid #0000;border-right:var(--plyr-tooltip-arrow-size,4px) solid #0000;border-top:4px solid #fff;border-top:var(--plyr-tooltip-arrow-size,4px) solid var(--plyr-tooltip-background,#fff);bottom:-4px;bottom:calc(var(--plyr-tooltip-arrow-size, 4px)*-1);content:"";height:0;left:calc(50% + var(--preview-arrow-offset));position:absolute;transform:translateX(-50%);width:0;z-index:2}.plyr__preview-thumb__image-container{background:#c1c8d1;border-radius:7px;border-radius:calc(var(--plyr-menu-radius, 8px) - 1px);overflow:hidden;position:relative;z-index:0}.plyr__preview-thumb__image-container img,.plyr__preview-thumb__image-container:after{height:100%;left:0;position:absolute;top:0;width:100%}.plyr__preview-thumb__image-container:after{border-radius:inherit;box-shadow:inset 0 0 0 1px #00000026;content:"";pointer-events:none}.plyr__preview-thumb__image-container img{max-height:none;max-width:none}.plyr__preview-thumb__time-container{background:linear-gradient(#0000,#000000bf);background:var(--plyr-video-controls-background,linear-gradient(#0000,#000000bf));border-bottom-left-radius:7px;border-bottom-left-radius:calc(var(--plyr-menu-radius, 8px) - 1px);border-bottom-right-radius:7px;border-bottom-right-radius:calc(var(--plyr-menu-radius, 8px) - 1px);bottom:0;left:0;line-height:1.1;padding:20px 6px 6px;position:absolute;right:0;z-index:3}.plyr__preview-thumb__time-container span{color:#fff;font-size:13px;font-size:var(--plyr-font-size-time,var(--plyr-font-size-small,13px))}.plyr__preview-scrubbing{bottom:0;filter:blur(1px);height:100%;left:0;margin:auto;opacity:0;overflow:hidden;pointer-events:none;position:absolute;right:0;top:0;transition:opacity .3s ease;width:100%;z-index:1}.plyr__preview-scrubbing--is-shown{opacity:1}.plyr__preview-scrubbing img{height:100%;left:0;max-height:none;max-width:none;object-fit:contain;position:absolute;top:0;width:100%}.plyr--no-transition{transition:none!important}.plyr__sr-only{clip:rect(1px,1px,1px,1px);border:0!important;height:1px!important;overflow:hidden;padding:0!important;position:absolute!important;width:1px!important}.plyr [hidden]{display:none!important}video[data-v-087ae83c] {
+  /* over arrows in tiny screens */
+  z-index: 20050;
+  align-self: center;
+  max-width: 100%;
+  max-height: 100% !important;
+  background-color: black;
+  justify-self: center;
+}
+[data-v-087ae83c]  .plyr:-webkit-full-screen video {
+  width: 100% !important;
+  height: 100% !important;
+}
+[data-v-087ae83c]  .plyr:fullscreen video {
+  width: 100% !important;
+  height: 100% !important;
+}
+[data-v-087ae83c]  .plyr__progress__container {
+  flex: 1 1;
+}
+[data-v-087ae83c]  .plyr {
+  --plyr-color-main: var(--color-primary-element);
+  --plyr-control-icon-size: 18px;
+  --plyr-menu-background: var(--color-main-background);
+  --plyr-menu-color: var(--color-main-text);
+  --plyr-audio-controls-background: var(--color-main-background);
+  --plyr-audio-control-color: var(--color-main-text);
+  --plyr-button-size: 44px;
+  --plyr-range-fill-background: var(--color-primary-element);
+}
+[data-v-087ae83c]  .plyr .plyr__controls {
+  flex-wrap: wrap;
+}
+[data-v-087ae83c]  .plyr .plyr__controls .plyr__volume,[data-v-087ae83c]  .plyr .plyr__controls .plyr__progress__container {
+  max-width: 100%;
+  flex: 1 1;
+}
+[data-v-087ae83c]  .plyr .plyr__controls .plyr__progress__container {
+  flex: 4 1;
+}
+[data-v-087ae83c]  .plyr button {
+  width: var(--plyr-button-size);
+  height: var(--plyr-button-size);
+  padding: calc((var(--plyr-button-size) - var(--plyr-control-icon-size)) / 2);
+  cursor: pointer;
+  border: none;
+  background-color: transparent;
+  line-height: inherit;
+}
+[data-v-087ae83c]  .plyr button:hover,[data-v-087ae83c]  .plyr button:focus {
+  color: var(--color-main-text);
+  background-color: var(--color-background-hover);
+}
+[data-v-087ae83c]  .plyr button.plyr__control--overlaid {
+  width: var(--plyr-button-size);
+  height: var(--plyr-button-size);
+  color: var(--color-primary-element-text);
+  background-color: var(--color-primary-element);
+  --plyr-button-size: 50px;
+}
+[data-v-087ae83c]  .plyr button.plyr__control--overlaid:hover,[data-v-087ae83c]  .plyr button.plyr__control--overlaid:focus {
+  background-color: var(--color-primary-element-hover);
+}
+[data-v-087ae83c]  .plyr .plyr__menu__container button {
+  width: 120px;
+  margin: 0;
+  color: var(--color-main-text);
+}
+[data-v-087ae83c]  .plyr .plyr__menu__container button:hover,[data-v-087ae83c]  .plyr .plyr__menu__container button:focus {
+  color: var(--color-main-text);
+  background-color: var(--color-background-hover);
+}
+[data-v-087ae83c]  .plyr .plyr__menu__container button.plyr__control--forward {
+  padding-right: 28px;
+  padding-right: calc(var(--plyr-control-spacing, 10px) * 0.7 * 4);
+}
+[data-v-087ae83c]  .plyr .plyr__menu__container button.plyr__control--back {
+  margin: calc(var(--plyr-control-spacing, 10px) * 0.7);
+  padding-left: 28px;
+  padding-left: calc(var(--plyr-control-spacing, 10px) * 0.7 * 4);
+}
+[data-v-087ae83c]  .plyr .plyr__progress__buffer {
+  width: calc(100% + var(--plyr-range-thumb-height, 13px));
+  height: var(--plyr-range-track-height, 5px);
+  background: transparent;
+}
+@media only screen and (max-width: 480px) {
+[data-v-087ae83c]  .plyr .plyr__volume {
+    display: none;
+}
+}
+[data-v-087ae83c]  .plyr button {
+  color: white;
+}
+[data-v-087ae83c]  .plyr button:hover,[data-v-087ae83c]  .plyr button:focus {
+  color: var(--color-primary-element-text);
+  background-color: var(--color-primary-element);
+}main.viewer__hidden-fullscreen {
+  height: 100vh !important;
+  width: 100vw !important;
+  margin: 0 !important;
+}
+footer.viewer__hidden-fullscreen {
+  display: none !important;
+}audio[data-v-2be0d851] {
+  /* over arrows in tiny screens */
+  z-index: 20050;
+  align-self: center;
+  max-width: 100%;
+  max-height: 100%;
+  background-color: black;
+  justify-self: center;
+}
+[data-v-2be0d851]  .plyr__progress__container {
+  flex: 1 1;
+}
+[data-v-2be0d851]  .plyr {
+  --plyr-color-main: var(--color-primary-element);
+  --plyr-control-icon-size: 18px;
+  --plyr-menu-background: var(--color-main-background);
+  --plyr-menu-color: var(--color-main-text);
+  --plyr-audio-controls-background: var(--color-main-background);
+  --plyr-audio-control-color: var(--color-main-text);
+  --plyr-button-size: 44px;
+  --plyr-range-fill-background: var(--color-primary-element);
+}
+[data-v-2be0d851]  .plyr .plyr__controls {
+  flex-wrap: wrap;
+}
+[data-v-2be0d851]  .plyr .plyr__controls .plyr__volume,[data-v-2be0d851]  .plyr .plyr__controls .plyr__progress__container {
+  max-width: 100%;
+  flex: 1 1;
+}
+[data-v-2be0d851]  .plyr .plyr__controls .plyr__progress__container {
+  flex: 4 1;
+}
+[data-v-2be0d851]  .plyr button {
+  width: var(--plyr-button-size);
+  height: var(--plyr-button-size);
+  padding: calc((var(--plyr-button-size) - var(--plyr-control-icon-size)) / 2);
+  cursor: pointer;
+  border: none;
+  background-color: transparent;
+  line-height: inherit;
+}
+[data-v-2be0d851]  .plyr button:hover,[data-v-2be0d851]  .plyr button:focus {
+  color: var(--color-main-text);
+  background-color: var(--color-background-hover);
+}
+[data-v-2be0d851]  .plyr button.plyr__control--overlaid {
+  width: var(--plyr-button-size);
+  height: var(--plyr-button-size);
+  color: var(--color-primary-element-text);
+  background-color: var(--color-primary-element);
+  --plyr-button-size: 50px;
+}
+[data-v-2be0d851]  .plyr button.plyr__control--overlaid:hover,[data-v-2be0d851]  .plyr button.plyr__control--overlaid:focus {
+  background-color: var(--color-primary-element-hover);
+}
+[data-v-2be0d851]  .plyr .plyr__menu__container button {
+  width: 120px;
+  margin: 0;
+  color: var(--color-main-text);
+}
+[data-v-2be0d851]  .plyr .plyr__menu__container button:hover,[data-v-2be0d851]  .plyr .plyr__menu__container button:focus {
+  color: var(--color-main-text);
+  background-color: var(--color-background-hover);
+}
+[data-v-2be0d851]  .plyr .plyr__menu__container button.plyr__control--forward {
+  padding-right: 28px;
+  padding-right: calc(var(--plyr-control-spacing, 10px) * 0.7 * 4);
+}
+[data-v-2be0d851]  .plyr .plyr__menu__container button.plyr__control--back {
+  margin: calc(var(--plyr-control-spacing, 10px) * 0.7);
+  padding-left: 28px;
+  padding-left: calc(var(--plyr-control-spacing, 10px) * 0.7 * 4);
+}
+[data-v-2be0d851]  .plyr .plyr__progress__buffer {
+  width: calc(100% + var(--plyr-range-thumb-height, 13px));
+  height: var(--plyr-range-track-height, 5px);
+  background: transparent;
+}
+@media only screen and (max-width: 480px) {
+[data-v-2be0d851]  .plyr .plyr__volume {
+    display: none;
+}
+}
+@media only screen and (max-width: 500px) {
+[data-v-2be0d851]  .plyr--audio {
+    top: calc(17.5vw + 30px);
+}
+}

--- a/css/viewer-main.css
+++ b/css/viewer-main.css
@@ -1,2 +1,2 @@
 /* extracted by css-entry-points-plugin */
-@import './main-BQpYvOBl.chunk.css';
+@import './main-Y8hU2k5s.chunk.css';

--- a/js/viewer-main.mjs
+++ b/js/viewer-main.mjs
@@ -121738,6 +121738,9 @@ const _sfc_main$2 = {
       };
     },
     livePhoto() {
+      if (this.metadataFilesLivePhoto === void 0) {
+        return void 0;
+      }
       return findLivePhotoPeerFromFileId(this.metadataFilesLivePhoto, this.fileList);
     },
     livePhotoSrc() {
@@ -122020,7 +122023,7 @@ var __component__$2 = /* @__PURE__ */ normalizeComponent$1(
   _sfc_staticRenderFns$2,
   false,
   null,
-  "ef7b99d0"
+  "d649c2f5"
 );
 const Images$1 = __component__$2.exports;
 /**

--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -163,6 +163,10 @@ export default {
 			}
 		},
 		livePhoto() {
+			if (this.metadataFilesLivePhoto === undefined) {
+				return undefined
+			}
+
 			return findLivePhotoPeerFromFileId(this.metadataFilesLivePhoto, this.fileList)
 		},
 		livePhotoSrc() {


### PR DESCRIPTION
If an item in the file list has an `undefined` `fileid`, this would have brought a false positive, causing an issue when rendering the file.

Might fix https://github.com/nextcloud/viewer/issues/2170