### PR TITLE
tests: Allow running cypress on different instance

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -64,6 +64,10 @@ export default defineConfig({
 				}
 			})
 
+			if (process.env.CYPRESS_baseUrl) {
+				return config
+			}
+
 			// Remove container after run
 			on('after:run', () => {
 				if (!process.env.CI) {


### PR DESCRIPTION
Allow running cypress tests without the integrated docker images by checking for CYPRESS_baseUrl environment variable presence.

Mid-term we should build arm images for ghcr.io/nextcloud/continuous-integration-shallow-server but for now this is the easiest way for me to run cypress tests locally on arm architecture.