### PR TITLE
Fix image viewer functionality for public shares in subfolders

### DIFF
--- a/src/views/Viewer.vue
+++ b/src/views/Viewer.vue
@@ -794,8 +794,10 @@ export default defineComponent({
 					sortingMode: this.sortingConfig.key,
 					sortingOrder: this.sortingConfig.asc ? 'asc' : 'desc',
 				})
-				this.fileList = sortedNodes.map(node => filteredFiles.find(file => file.filename === node.path))
 
+				this.fileList = sortedNodes.map(node => {
+					return filteredFiles.find(file => file.filename === String(dirPath + node.path))
+				})
 				// store current position
 				this.currentIndex = this.fileList.findIndex(file => file.filename === fileInfo.filename)
 				this.updatePreviousNext()


### PR DESCRIPTION
Fix: Added the `dirPath` to the `node.path` for file comparisons in public shares, enabling the image viewer to function correctly when accessing images within subfolders. This resolves the issue where users could not navigate through images in subfolders when sharing the parent folder publicly.

I couldn't get the alternative of using `fileid` attribute for both working for whatever reason. 

Fixes #2977. Fixes #2976

Description of bug:

In commit [cce1e1d](https://github.com/nextcloud/viewer/commit/cce1e1d), a new sort was introduced that compared `node.path` to `file.filename`. In a public file share, the `node.dirname` is evaluating to `/` even within a subfolder so  `node.path` (which seems to be`${node.dirname}${node.basename}`) is always `/${node.basename}`. However,`file.filename is `dirPath/displayname`. Thus, if one attempts to scroll through in the top level of a public share, `node.path` is the same as `file.filename` since `dirPath` is `node.dirname`, that is `/`. However, in a nested path, we get this mismatch. Since we are unable to change the `path` for the NcFile, I appended the `dirPath` during the filter. 

Alternatively, the better approach would be rectify the path variable for the NcFile but I didn't see a method to do that. 

I tested this using the dev repo (https://github.com/juliusknorr/nextcloud-docker-dev) and copied all the files from `Media` into a subfolder called `images` and shared the `Media` folder using a public link to get the following: 

Using Big_Buck_Bunny_1080_10s_10MB.mkv in `Media`:
```
logger.error(`sortedNode.path: ${String(sortedNodes[0].path)}`) // /Big_Buck_Bunny_1080_10s_10MB.mkv
logger.error(`sortedNode.filename: ${String(sortedNodes[0].filename)}`) // /Big_Buck_Bunny_1080_10s_10MB.mkv
```

Using Big_Buck_Bunny_1080_10s_10MB.mkv in `Media/images`:
```
logger.error(`sortedNode.path: ${String(sortedNodes[0].path)}`) // /Big_Buck_Bunny_1080_10s_10MB.mkv
logger.error(`sortedNode.filename: ${String(sortedNodes[0].filename)}`) // /images/Big_Buck_Bunny_1080_10s_10MB.mkv
```

`tree .`
```
.
|-- Media
|   |-- Big_Buck_Bunny_1080_10s_10MB.mkv
|   |-- images
|   |   |-- Big_Buck_Bunny_1080_10s_10MB.mkv
|   |   |-- photo-1495962637988-4be9db2af01f.jpeg
|   |   |-- photo-1498855592392-af2bf1e0a4c7.jpeg
|   |   |-- photo-1503991721143-75f95ebf1e55.jpeg
|   |   |-- photo-1517603250781-c4eac1449a80.jpeg
|   |   |-- photo-1527668441211-67a036f77ab4.jpeg
|   |   |-- photo-1532597751369-606119ceda8a.jpeg
|   |   `-- photo-1533658925625-2f94d23fc425.jpeg
|   |-- photo-1495962637988-4be9db2af01f.jpeg
|   |-- photo-1498855592392-af2bf1e0a4c7.jpeg
|   |-- photo-1503991721143-75f95ebf1e55.jpeg
|   |-- photo-1517603250781-c4eac1449a80.jpeg
|   |-- photo-1527668441211-67a036f77ab4.jpeg
|   |-- photo-1532597751369-606119ceda8a.jpeg
|   `-- photo-1533658925625-2f94d23fc425.jpeg
|-- Nextcloud_Server_Administration_Manual.pdf
`-- Templates
```

