### PR TITLE
fix(viewer): used join to fix issues stemming from #2991

### DIFF
--- a/src/views/Viewer.vue
+++ b/src/views/Viewer.vue
@@ -798,8 +798,12 @@ export default defineComponent({
 					sortingOrder: this.sortingConfig.asc ? 'asc' : 'desc',
 				})
 
+				let tmp_path
+				tmp_path = dirPath
+				if (tmp_path.length === 0 ) {tmp_path = "/"}
+
 				this.fileList = sortedNodes.map(node => {
-					return filteredFiles.find(file => file.filename === join(dirPath, node.basename))
+					return filteredFiles.find(file => file.filename === join(tmp_path, node.basename))
 				})
 				// store current position
 				this.currentIndex = this.fileList.findIndex(file => file.filename === fileInfo.filename)


### PR DESCRIPTION
While the fix merged in #2991 addressed a share, it inadvertently broke navigating through images for regular file viewing (non-shares). This fix uses the `join`, `dirPath` and `node.basename` to reconstruct the paths that works for both shares and non-shared views.


I've tested this lean version of the nextcloud-docker-dev repo as of 2025-Oct-27 for (1) regular file navigation, (2) the root of a share for images and (3) within subfolders for the share. The check for length 0 is needed for images in the root of a share. Originally, the dirPath evaluated to `/` but now it evaluates to an empty string. 


Sorry @skjnldsv about the headache that this has caused.