### PR TITLE
Add option to show original image in viewer instead of showing a preview

### DIFF
--- a/lib/Listener/LoadViewerScript.php
+++ b/lib/Listener/LoadViewerScript.php
@@ -14,6 +14,7 @@ use OCA\Viewer\Event\LoadViewer;
 use OCP\AppFramework\Services\IInitialState;
 use OCP\EventDispatcher\Event;
 use OCP\EventDispatcher\IEventListener;
+use OCP\IConfig;
 use OCP\IPreview;
 use OCP\Util;
 
@@ -22,13 +23,16 @@ use OCP\Util;
  * @psalm-api
  */
 class LoadViewerScript implements IEventListener {
+	private IConfig $config;
 	private IInitialState $initialStateService;
 	private IPreview $previewManager;
 
 	public function __construct(
+		IConfig $config,
 		IInitialState $initialStateService,
 		IPreview $previewManager,
 	) {
+		$this->config = $config;
 		$this->initialStateService = $initialStateService;
 		$this->previewManager = $previewManager;
 	}
@@ -43,5 +47,10 @@ class LoadViewerScript implements IEventListener {
 		Util::addInitScript(Application::APP_ID, 'viewer-init');
 		Util::addScript(Application::APP_ID, 'viewer-main', 'files');
 		$this->initialStateService->provideInitialState('enabled_preview_providers', array_keys($this->previewManager->getProviders()));
+		$this->initialStateService->provideInitialState('disable_preview',$this->getSystemValue('disable_preview_in_viewer'));
 	}
+
+	public function getSystemValue(string $key) {
+        return $this->config->getSystemValue($key, false);
+    }
 }

--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -88,6 +88,8 @@ import { findLivePhotoPeerFromFileId } from '../utils/livePhotoUtils'
 import { getDavPath } from '../utils/fileUtils'
 import { preloadMedia } from '../services/mediaPreloader'
 
+import { loadState } from '@nextcloud/initial-state'
+
 Vue.use(AsyncComputed)
 
 export default {
@@ -117,6 +119,7 @@ export default {
 			pinchDistance: 0,
 			pinchStartZoomRatio: 1,
 			pointerCache: [],
+			disablePreview: loadState(appName, 'disable_preview', false)
 		}
 	},
 
@@ -178,6 +181,11 @@ export default {
 			// Load the raw gif instead of the static preview
 			if (this.mime === 'image/gif') {
 				return this.src
+			}
+
+			// If disablePreview is set in config.php then return the original file source
+			if(this.disablePreview) {
+				return this.src;
 			}
 
 			// If there is no preview and we have a direct source


### PR DESCRIPTION
This is a PR to integrate a simple option to disable previews for images in the viewer. I'm still pretty new to nextcloud development and I don't really know VueJS. So this might not be up to some code standards. If you know a thing I can improve leave a comment and I will try to adapt it.

I know this topic has a very long discussion history with both sides actually having solid use cases for showing previews vs. showing original Images. As someone who only has Images that are 1-2 MB in size I never really had the urge for preview files and instead would like to see the full resolution image.
In my opinion the best solution for the issue is having a setting so that both sides can be happy.

With my change I added a setting that can be set via config.php to disable the previews in the viewer. The default case still remains the same so that previews are being displayed. Anyone that does want to view original images however can set the Option `disable_preview_in_viewer` to true and get the original image shown.
  