### PR TITLE
Security: Potential Cross-Site Scripting (XSS) via Unescaped User Input in Error Component

### DIFF
--- a/src/components/Error.vue
+++ b/src/components/Error.vue
@@ -7,12 +7,14 @@
 	<div id="emptycontent">
 		<div class="icon-error" />
 		<h2>
-			<slot>{{ t('viewer', 'Error loading {name}', { name }) }}</slot>
+			<slot>{{ t('viewer', 'Error loading {name}', { name: escapeHtml(name) }) }}</slot>
 		</h2>
 	</div>
 </template>
 
 <script>
+import { escapeHtml } from '../utils/escapeHtml.js'
+
 export default {
 	name: 'Error',
 
@@ -21,6 +23,10 @@ export default {
 			type: String,
 			default: '',
 		},
+	},
+
+	methods: {
+		escapeHtml,
 	},
 }
 </script>


### PR DESCRIPTION
## Summary

Security: Potential Cross-Site Scripting (XSS) via Unescaped User Input in Error Component

## Problem

**Severity**: `Medium` | **File**: `src/components/Error.vue:L10`

The Error.vue component uses a slot with user-provided `name` prop inside a translation function `t('viewer', 'Error loading {name}', { name })`. While Vue's template rendering provides some escaping, if the `t` function or the slot content processes raw HTML or if the name prop is rendered as raw HTML elsewhere, this could lead to XSS. The component receives `name` as a prop without any visible sanitization.

## Solution

Ensure the `t` function properly escapes all interpolated variables. Consider using Vue's `v-html` only when necessary and never with user input. Add explicit HTML sanitization for the `name` prop before passing it to the translation function.

## Changes

- `src/components/Error.vue` (modified)