### PR TITLE
[stable34] fix(composer): Remove trailing comma breaking composer.json parsing

### DIFF
--- a/composer/composer.json
+++ b/composer/composer.json
@@ -4,7 +4,7 @@
 		"vendor-dir": ".",
 		"optimize-autoloader": true,
 		"classmap-authoritative": true,
-		"autoloader-suffix": "Viewer",
+		"autoloader-suffix": "Viewer"
 	},
 	"autoload": {
 		"psr-4": {


### PR DESCRIPTION
The trailing comma after "autoloader-suffix" made composer/composer.json invalid JSON.

Assisted-by: Claude Code:claude-fable-5



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
