### PR TITLE
[stable33] chore: replace node.yml workflow with npm-build.yml

### DIFF
--- a/.github/workflows/npm-build.yml
+++ b/.github/workflows/npm-build.yml
@@ -6,7 +6,7 @@
 # SPDX-FileCopyrightText: 2021-2024 Nextcloud GmbH and Nextcloud contributors
 # SPDX-License-Identifier: MIT
 
-name: Node
+name: Build Javascript
 
 on: pull_request
 
@@ -53,7 +53,7 @@ jobs:
     name: NPM build
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -65,7 +65,7 @@ jobs:
           fallbackNpm: '^11.3'
 
       - name: Set up node ${{ steps.versions.outputs.nodeVersion }}
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ steps.versions.outputs.nodeVersion }}
 


### PR DESCRIPTION
Mirrors master commits 1abbd15e (add npm-build.yml) and d930a5ae (delete node.yml).

_This PR was developed with AI assistance (Claude Code)._