### PR TITLE
fix(Images): do not capture pointer, wheel and touch input when zoom is disabled

### DIFF
--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -18,13 +18,14 @@
 				:class="{
 					dragging,
 					loaded,
-					zoomed: zoomRatio > 1
+					zoomed: zoomRatio > 1,
+					canZoom
 				}"
 				:src="data"
 				:style="imgStyle"
 				@error.capture.prevent.stop.once="onFail"
 				@load="updateImgSize"
-				@wheel.stop.prevent="updateZoom"
+				@wheel="updateZoom"
 				@dblclick.prevent="onDblclick"
 				@pointerdown.prevent="pointerDown"
 				@pointerup.prevent="pointerUp"
@@ -36,7 +37,8 @@
 					:class="{
 						dragging,
 						loaded,
-						zoomed: zoomRatio > 1
+						zoomed: zoomRatio > 1,
+						canZoom
 					}"
 					:style="imgStyle"
 					:playsinline="true"
@@ -45,7 +47,7 @@
 					preload="metadata"
 					@canplaythrough="doneLoadingLivePhoto"
 					@loadedmetadata="updateImgSize"
-					@wheel.stop.prevent="updateZoom"
+					@wheel="updateZoom"
 					@error.capture.prevent.stop.once="onFail"
 					@dblclick.prevent="onDblclick"
 					@pointerdown.prevent="pointerDown"
@@ -293,6 +295,8 @@ export default {
 			if (!this.canZoom) {
 				return
 			}
+			event.stopPropagation()
+			event.preventDefault()
 
 			const isZoomIn = event.deltaY < 0
 			const newZoomRatio = isZoomIn
@@ -325,8 +329,8 @@ export default {
 		 */
 		pointerDown(event) {
 			if (!this.canZoom) {
-     			   return
-    			}
+				return
+			}
 			// New pointer - mouse down or additional touch --> store client coordinates in the pointer cache
 			this.pointerCache.push({ pointerId: event.pointerId, x: event.clientX, y: event.clientY })
 
@@ -472,7 +476,6 @@ img, video {
 	background-color: #000;
 	// disable animations during zooming/resize
 	transition: none !important;
-	touch-action: none;
 	// show checkered bg on hover if not currently zooming (but ok if zoomed)
 	&:hover {
 		background-image: linear-gradient(45deg, #{$checkered-color} 25%, transparent 25%),
@@ -494,6 +497,13 @@ img, video {
 	&.dragging {
 		transition: none !important;
 		cursor: move;
+	}
+
+	// only claim wheel/touch gestures when zoom is actually available;
+	// otherwise let the browser scroll the page as normal (canZoom=false
+	// in embedded previews, e.g. the Smart Picker file-link widget)
+	&.canZoom {
+		touch-action: none;
 	}
 }
 

--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -324,6 +324,9 @@ export default {
 		 * @param {DragEvent} event the event
 		 */
 		pointerDown(event) {
+			if (!this.canZoom) {
+     			   return
+    			}
 			// New pointer - mouse down or additional touch --> store client coordinates in the pointer cache
 			this.pointerCache.push({ pointerId: event.pointerId, x: event.clientX, y: event.clientY })
 


### PR DESCRIPTION
## Summary

When you share an image with the smart picker in Talk, you can't scroll over it. It also eats drag attempts, showing a pan cursor but not panning anything. This PR removes these. First commit removes the pan, the second takes care of scroll/zoom events.

The pan removal thing is a very simple fix, just adding a !canZoom to the relevant functions. The second is slightly more involved, moving some stuff around.

To be clear, it'd be nicer to be able to add actual zoom/pan, but I'm not sure how feasible that is in that space, in a way that works everywhere. Plus, you might say - instead of zoom, we should open the full viewer on click. Also makes sense if you ask me... So, hum, something to discuss with the design team first.

Below analysis from Claude:

🤖 -----------
## Cause

In `Images.vue`, `pointerDown()` sets `dragging = true` unconditionally — unlike `updateZoom()`, `pointerMove()`, and `onDblclick()`, which all early-return when `!canZoom`. Combined with the `.dragging { cursor: move }` style, this shows the pan cursor even though `pointerMove()` only pans when `zoomRatio > 1`, which can never happen while `canZoom` is false (what the Files widget passes).

## Change

Early-return at the top of `pointerDown()` when `!this.canZoom`. The rest of that method only maintains the pinch-zoom pointer cache, which is dead code when zoom is disabled.

----------  😶‍🌫️ 

Scroll capture is a little bigger (in second commit, which also fixes my tabs/spaces mixup):

Removed `.stop.prevent` from `@wheel` on both `<img>` and `<video>`, moved `event.stopPropagation()/event.preventDefault()` inside `updateZoom()` right after the `canZoom` guard.

And touch scroll capture:

Removed the bare `touch-action: none` from the base `img`, `video` rule, added a `canZoom` class to both elements (bound to the existing `canZoom` prop) and scoped touch-action: none under `&.canZoom`.

## Testing

- `npm run lint` passes.
- Manually verified: cursor is normal when hovering an embedded preview and it no longer eats your scroll events; unchanged (move cursor, working pan/zoom) inside the modal.

Screenshot doesn't really make a ton of sense, I mean, it won't show a drag icon if you try to drag and you can scroll...

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI

Assisted-by: Claude Sonnet 5:claude-sonnet-5
