### PR TITLE
fix(Mime): do not set natural dimensions when embedded

### DIFF
--- a/src/components/Images.vue
+++ b/src/components/Images.vue
@@ -18,7 +18,8 @@
 				:class="{
 					dragging,
 					loaded,
-					zoomed: zoomRatio > 1
+					zoomed: zoomRatio > 1,
+					embedded: isEmbedded
 				}"
 				:src="data"
 				:style="imgStyle"
@@ -36,7 +37,8 @@
 					:class="{
 						dragging,
 						loaded,
-						zoomed: zoomRatio > 1
+						zoomed: zoomRatio > 1,
+						embedded: isEmbedded
 					}"
 					:style="imgStyle"
 					:playsinline="true"
@@ -134,6 +136,10 @@ export default {
 			return this.basename
 		},
 		imgStyle() {
+			// let CSS size the element instead of forcing dimensions in JS
+			if (this.isEmbedded) {
+				return {}
+			}
 			if (this.zoomRatio === 1) {
 				return {
 					height: this.zoomHeight + 'px',
@@ -491,6 +497,14 @@ img, video {
 	&.dragging {
 		transition: none !important;
 		cursor: move;
+	}
+
+	&.embedded {
+		max-width: 100%;
+		max-height: 100%;
+		width: auto;
+		height: auto;
+		object-fit: contain;
 	}
 }
 

--- a/src/mixins/Mime.js
+++ b/src/mixins/Mime.js
@@ -85,6 +85,11 @@ export default {
 			type: Number,
 			default: undefined,
 		},
+		// is the component mounted outside of the viewer modal?
+		isEmbedded: {
+			type: Boolean,
+			default: false,
+		},
 	},
 
 	data() {
@@ -157,6 +162,11 @@ export default {
 		 * based on the viewer maximum size
 		 */
 		updateHeightWidth() {
+			// let CSS size the element when mounted outside of the viewer modal
+			if (this.isEmbedded) {
+				return
+			}
+
 			const modalWrapper = this.$parent.$el.querySelector('.modal-wrapper')
 			if (modalWrapper && this.naturalHeight > 0 && this.naturalWidth > 0) {
 				const modalContainer = modalWrapper.querySelector('.modal-container')


### PR DESCRIPTION
When using the Smart Picker to view an image, the size of these images is shared with the app, and both Talk and Text take try and display them as such. Now Talk has a different CSS that kind of limits the damage, but it doesn't look great either. Screenshots:

BEFORE: Talk will basically make it fit, distorting the image:
<img width="852" height="744" alt="Screenshot 2026-08-23 at 23 09 09" src="https://github.com/user-attachments/assets/f80f6c5e-edcb-44fe-b3b5-6ef3ccde7462" />

AFTER: No more distortion!
<img width="852" height="910" alt="Screenshot 2026-08-23 at 23 20 39" src="https://github.com/user-attachments/assets/0901eeba-eae7-4284-8bc6-16693e27d258" />

BEFORE: Text just crops (the image on the bottom is the link to the same file as the attachment above it):
<img width="852" height="910" alt="Screenshot 2026-08-23 at 23 14 02" src="https://github.com/user-attachments/assets/818489c3-4151-412e-9ef3-4f6ce4b96f36" />

AFTER: Looks just fine, can even be resized.
<img width="852" height="910" alt="Screenshot 2026-08-23 at 23 16 50" src="https://github.com/user-attachments/assets/bea964d0-21cb-4912-80bb-802453801cf7" />

BEFORE: In Text, Tables are entirely broken by inserting an image, as it's rendered 1:1 size and thus creates a huge horizontal scroll.
<img width="852" height="910" alt="Screenshot 2026-08-23 at 23 19 11" src="https://github.com/user-attachments/assets/2b299b29-2e04-4b0e-b7f9-9dde2d6a7585" />

AFTER: fits nicely in a table cell;
<img width="852" height="910" alt="Screenshot 2026-08-23 at 23 18 03" src="https://github.com/user-attachments/assets/c39508c9-6e6d-48b4-b3b4-1fa2874cd6fe" />

Makes images a lot more useful this way. It does not impact the viewer modal at all - checked that from Talk, Files and Text.

## The cause
To let Claude explain the cause of this:

`Mime.js`'s `updateHeightWidth()` decided whether it was running inside the modal by searching the parent DOM for `.modal-wrapper`. Anywhere else, it fell through to natural image/video size and wrote that out as a hardcoded inline style, e.g. `style="height: 1912px; width: 2940px"`. The widget's container has `overflow: hidden`, so only the top-left corner of the image is visible, and in a table cell the oversized intrinsic width blows out the column.

## Change

This is what was changed (Claude's words);

- Declare a new `isEmbedded` prop on the `Mime` mixin. The Files widget already passes `is-embedded="true"` to the handler component, but nothing declared the prop, so it was silently swallowed into `$attrs`.
- Return early from `updateHeightWidth()` when `isEmbedded` is set, leaving `height`/`width` unset. The existing `else` branch (natural dimensions not yet measured, inside the modal) is untouched.
- `Images.vue`'s `imgStyle` returns `{}` when embedded, instead of computing `Math.round(null * zoomRatio)` → `0`, which would otherwise render `style="height: 0px; width: 0px"` and blank the widget entirely.
- Add a `.embedded` CSS modifier (`max-width/max-height: 100%`, `object-fit: contain`) so the browser sizes the element instead, preserving aspect ratio without upscaling small images.

Applications can work around this bug in their own CSS (Text, Talk), but that's less than ideal.

## Testing

- `npm run lint` and `npm run stylelint` pass.
- Manually verified in the browser: large image, small image (not upscaled).
- Inside the modal: no visual change. Verified zoom, pan, pinch-zoom, swipe between files.

## 🤖 AI (if applicable)

Assisted-by: Claude Sonnet 5:claude-sonnet-5

Frankly, Claude did the code/analysis. I tested etc...

- [x] The content of this PR was partly or fully generated using AI
