### PR TITLE
fix: optimize file lookup for large folders

### DIFF
--- a/src/views/Viewer.vue
+++ b/src/views/Viewer.vue
@@ -841,8 +841,12 @@ export default defineComponent({
 					sortingOrder: this.sortingConfig.asc ? 'asc' : 'desc',
 				})
 
+				const filesByPath = new Map(
+					filteredFiles.map(file => [file.filename, file]),
+				)
+
 				this.fileList = sortedNodes.map(node => {
-					return filteredFiles.find(file => file.filename === node.path)
+					return filesByPath.get(node.path)
 				})
 				// store current position
 				this.currentIndex = this.fileList.findIndex(file => file.filename === fileInfo.filename)


### PR DESCRIPTION
Replaced the previous O(N^2) file lookup with one that:
1. Builds the map of the files with the path
2. Iterates over the sorted nodes and retrieves each file from the map

This turns the O(N^2) lookup into 2 O(N) operations Tested on a folder with about 10 000 files
this cuts down the time to finish enumerating fromabout 90 seconds to about 11 seconds
Also fixes the browser becoming unresponsive for that time

fixes: #3217 and #3015 
I didn't see those before and didn't see that something was already in the works
You can choose to not merge it and wait for the changes mentioned in those issues

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
